### PR TITLE
Make suggested changes to disk bar implementation

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -25,16 +25,6 @@ textview.terminal selection {
     color: #252e32;
 }
 
-.partition {
-    border-style: solid;
-    border-right-width: 1px;
-}
-
-.disk-bar {
-    border-style: solid;
-    border-width: 1px;
-}
-
 .ext2, .ext3, .ext4 {
     background-color: rgb(114, 147, 203);
 }

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -75,17 +75,8 @@ public class Installer.PartitioningView : AbstractInstallerView  {
                 partitions.append_val (partition);
             }
 
-            for (int i = 0; i < partitions.length ; i++) {
-                var part = partitions.index(i);
-                part.add_events (Gdk.EventMask.BUTTON_PRESS_MASK);
-                part.button_press_event.connect (() => {
-                    part.show_popover();
-                });
-            }
-
-            var disk_bar = new DiskBar (model, path, size, partitions);
-            disk_list.attach(disk_bar.label, 0, id, 1, 1);
-            disk_list.attach(disk_bar, 1, id, 1, 1);
+            var disk_bar = new DiskBar (model, path, size, (owned) partitions);
+            disk_list.attach(disk_bar, 0, id);
 
             id += 1;
         }


### PR DESCRIPTION
- Less DiskBar-specific code in PartitioningView, more code in DiskBar
- GObject initialization instead of normal initialization
- Switch to using the suggested classes for the disk bar and its partitions.
- Some elementary style fixes
- DiskBar now takes ownership of the partitions vector it receives
