### PR TITLE
Replace GLib.Array<T> with Gee.ArrayList<T>

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -190,7 +190,7 @@ public class Installer.MainWindow : Gtk.Dialog {
         disk_view.next_step.connect (() => load_progress_view (null));
     }
 
-    private void load_progress_view (GLib.Array<Installer.Mount>? disk_config) {
+    private void load_progress_view (Gee.ArrayList<Installer.Mount>? disk_config) {
         if (progress_view != null) {
             progress_view.destroy ();
         }

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -26,7 +26,7 @@ public class Installer.PartitioningView : AbstractInstallerView  {
     private Distinst.Disks disks;
     private Gtk.Grid disk_list;
 
-    public GLib.Array<Installer.Mount> mounts;
+    public Gee.ArrayList<Installer.Mount> mounts;
 
     public static uint64 minimum_disk_size;
 
@@ -36,7 +36,7 @@ public class Installer.PartitioningView : AbstractInstallerView  {
     }
 
     construct {
-        this.mounts = new GLib.Array<Installer.Mount> ();
+        this.mounts = new Gee.ArrayList<Installer.Mount> ();
         this.margin = 12;
         disk_list = new Gtk.Grid ();
         disk_list.set_valign (Gtk.Align.START);
@@ -90,10 +90,10 @@ public class Installer.PartitioningView : AbstractInstallerView  {
                 label = model;
             }
 
-            var partitions = new GLib.Array<PartitionBar> ();
+            var partitions = new Gee.ArrayList<PartitionBar> ();
             foreach (unowned Distinst.Partition part in disk.list_partitions ()) {
                 var partition = new PartitionBar (part, path, sector_size, this.set_mount, this.unset_mount);
-                partitions.append_val (partition);
+                partitions.add (partition);
             }
 
             var disk_bar = new DiskBar (model, path, size, (owned) partitions);
@@ -118,7 +118,7 @@ public class Installer.PartitioningView : AbstractInstallerView  {
 
     private void reset_view () {
         disk_list.get_children ().foreach ((child) => child.destroy ());
-        mounts.remove_range (0, mounts.length);
+        mounts.clear ();
         next_button.sensitive = false;
         load_disks ();
     }
@@ -129,8 +129,8 @@ public class Installer.PartitioningView : AbstractInstallerView  {
         const uint8 BOOT = 2;
 
         stderr.printf("DEBUG: Current Layout:\n");
-        foreach (unowned Mount m in mounts.data) {
-            stderr.printf("  %s : %s\n", m.partition_path, m.mount_point);
+        foreach (Mount m in mounts) {
+            stderr.printf("  %s : %s : %s\n", m.partition_path, m.mount_point, Distinst.strfilesys (m.filesystem));
             if (m.mount_point == "/" && m.is_valid_root_mount ()) {
                 flags |= ROOT;
             } else if (m.mount_point == "/boot/efi" && m.is_valid_boot_mount ()) {
@@ -148,8 +148,15 @@ public class Installer.PartitioningView : AbstractInstallerView  {
 
     private void set_mount (Mount mount) {
         unset_mount_point (mount);
-        remove_mount_by_partition (mount.partition_path);
-        this.mounts.append_val (mount);
+        for (int i = 0; i < mounts.size; i++) {
+            if (mounts[i].partition_path == mount.partition_path) {
+                mounts[i] = mount;
+                validate_status ();
+                return;
+            }
+        }
+
+        mounts.add (mount);
         validate_status ();
     }
 
@@ -159,20 +166,17 @@ public class Installer.PartitioningView : AbstractInstallerView  {
     }
 
     private void remove_mount_by_partition (string partition) {
-        for (int i = 0; i < mounts.length; i++) {
-            var m = mounts.index (i);
-            if (m.partition_path == partition) {
-                mounts.remove_index (i);
+        for (int i = 0; i < mounts.size; i++) {
+            if (mounts[i].partition_path == partition) {
+                mounts.remove_at (i);
                 break;
             }
         }
     }
 
     private void unset_mount_point (Mount src) {
-        var found_mount = false;
-        int i = 0;
-        for (; i < mounts.length; i++) {
-            var m = mounts.index (i);
+        for (int i = 0; i < mounts.size; i++) {
+            var m = mounts[i];
             if (m.mount_point == src.mount_point && m.partition_path != src.partition_path) {
                 m.menu.disable_signals = true;
                 m.menu.use_partition.active = false;
@@ -184,13 +188,9 @@ public class Installer.PartitioningView : AbstractInstallerView  {
                 m.menu.custom.set_visible (false);
                 m.menu.custom_label.set_visible (false);
                 m.menu.disable_signals = false;
-                found_mount = true;
+                mounts.remove_at (i);
                 break;
             }
-        }
-
-        if (found_mount) {
-            mounts.remove_index (i);
         }
     }
 }

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -20,7 +20,7 @@ public class ProgressView : AbstractInstallerView {
     public signal void on_success ();
     public signal void on_error ();
 
-    private GLib.Array<Installer.Mount>? disk_config;
+    private Gee.ArrayList<Installer.Mount>? disk_config;
 
     private double prev_upper_adj = 0;
     private Gtk.ScrolledWindow terminal_output;
@@ -29,7 +29,7 @@ public class ProgressView : AbstractInstallerView {
     private Gtk.Label progressbar_label;
     private const int NUM_STEP = 5;
 
-    public ProgressView (GLib.Array<Installer.Mount>? mounts) {
+    public ProgressView (Gee.ArrayList<Installer.Mount>? mounts) {
         if (mounts == null) {
             stderr.printf ("mounts is null\n");
         }
@@ -184,9 +184,7 @@ public class ProgressView : AbstractInstallerView {
     }
 
     private void custom_disk_configuration (Distinst.Disks disks) {
-        for (int i = 0; i < disk_config.length ; i++) {
-            var m = disk_config.index (i);
-
+        foreach (Installer.Mount m in disk_config) {
             unowned Distinst.Disk disk = disks.get_physical_device (m.parent_disk);
             if (disk == null) {
                 var new_disk = new Distinst.Disk (m.parent_disk);

--- a/src/Widgets/DiskBar.vala
+++ b/src/Widgets/DiskBar.vala
@@ -22,12 +22,11 @@ public class Installer.DiskBar: Gtk.Grid {
     public string disk_name { get; construct; }
     public string disk_path { get; construct; }
     public uint64 size { get; construct; }
-    public GLib.Array<PartitionBar> partitions { get; construct; }
+    public Gee.ArrayList<PartitionBar> partitions { get; construct; }
 
     private Gtk.Box label;
     private Gtk.Box bar;
     private Gtk.Box legend_container;
-    private Gtk.Box bar_container;
     private uint64 unused;
     private Gtk.Box unused_bar;
 
@@ -35,7 +34,7 @@ public class Installer.DiskBar: Gtk.Grid {
         string model,
         string path,
         uint64 size,
-        GLib.Array<PartitionBar> partitions
+        Gee.ArrayList<PartitionBar> partitions
     ) {
         Object (
             disk_name: model,
@@ -71,8 +70,8 @@ public class Installer.DiskBar: Gtk.Grid {
 
     private uint64 get_unused () {
         uint64 used = 0;
-        for (int i = 0; i < partitions.length; i++) {
-            used += partitions.index (i).get_size ();
+        foreach (PartitionBar partition in partitions) {
+            used += partition.get_size ();
         }
 
         return size - (used * 512);
@@ -82,8 +81,7 @@ public class Installer.DiskBar: Gtk.Grid {
         legend_container = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
         legend_container.set_halign (Gtk.Align.CENTER);
 
-        for (int i = 0; i < partitions.length; i++) {
-            var p = partitions.index (i);
+        foreach (PartitionBar p in partitions) {
             add_legend (p.path, p.get_size() * 512, Distinst.strfilesys (p.filesystem));
         }
 
@@ -142,8 +140,7 @@ public class Installer.DiskBar: Gtk.Grid {
             update_sector_lengths (partitions, alloc.width);
         });
 
-        for (int i = 0; i < partitions.length; i++) {
-            var part = partitions.index (i);
+        foreach (PartitionBar part in partitions) {
             part.update_length (1000, this.size / 512);
             bar.pack_start(part, false, false, 0);
         }
@@ -151,10 +148,10 @@ public class Installer.DiskBar: Gtk.Grid {
         bar.pack_start (unused_bar, true, true, 0);
     }
 
-    public void update_sector_lengths (GLib.Array<PartitionBar> partitions, int alloc_width) {
+    public void update_sector_lengths (Gee.ArrayList<PartitionBar> partitions, int alloc_width) {
         var disk_sectors = this.size / 512;
-        for (int i = 0; i < partitions.length; i++) {
-            partitions.index (i).update_length (alloc_width, disk_sectors);
+        foreach (PartitionBar partition in partitions) {
+            partition.update_length (alloc_width, disk_sectors);
         }
 
         var unused_size = unused / 512;


### PR DESCRIPTION
I've learned that `Gee.ArrayList<T>` is the preferred vector type for Vala, rather than `GLib.Array<T>`, so I've went through and replaced all of my usage of `GLib.Array`. In doing so, I've also fixed the mount setting so that the mount points are updated, rather than removed & re-added. May need some testing just to make sure it hasn't broken anything. It seems to be working on my end.

I've also added the file system to the layout debug string printed to stderr, just to make sure that file systems aren't also affected by the mount point issue.