### PR TITLE
Make Legends Scrollable

### DIFF
--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -41,6 +41,8 @@ public class Installer.PartitioningView : AbstractInstallerView  {
         disk_list = new Gtk.Grid ();
         disk_list.set_valign (Gtk.Align.START);
         disk_list.row_spacing = 6;
+        disk_list.margin_end = 12;
+
         var disk_scroller = new Gtk.ScrolledWindow (null, null);
         disk_scroller.hexpand = true;
         disk_scroller.hscrollbar_policy = Gtk.PolicyType.NEVER;
@@ -49,8 +51,8 @@ public class Installer.PartitioningView : AbstractInstallerView  {
         var description = new Gtk.Label (_("Select which partitions to use across all drives. This will erase all data on the selected partitions."));
         description.set_halign (Gtk.Align.CENTER);
 
-        this.content_area.attach (description, 0, 0, 1, 1);
-        this.content_area.attach (disk_scroller, 0, 1, 1, 1);
+        this.content_area.attach(description, 0, 0);
+        this.content_area.attach(disk_scroller, 0, 1);
 
         load_disks ();
 

--- a/src/Widgets/DiskBar.vala
+++ b/src/Widgets/DiskBar.vala
@@ -26,6 +26,7 @@ public class Installer.DiskBar: Gtk.Grid {
 
     public Gtk.Box label;
     private Gtk.Box bar;
+    private Gtk.ScrolledWindow legend;
     private Gtk.Box legend_container;
     private uint64 unused;
     private Gtk.Box unused_bar;
@@ -51,10 +52,9 @@ public class Installer.DiskBar: Gtk.Grid {
         generate_legend ();
 
         this.hexpand = true;
-        this.row_spacing = 6;
         this.get_style_context ().add_class ("storage-bar");
         this.attach (label, 0, 1);
-        this.attach (legend_container, 1, 0);
+        this.attach (legend, 1, 0);
         this.attach (bar, 1, 1);
         this.margin = 6;
 
@@ -71,8 +71,13 @@ public class Installer.DiskBar: Gtk.Grid {
     }
 
     private void generate_legend () {
+        legend = new Gtk.ScrolledWindow (null, null);
+        legend.vscrollbar_policy = Gtk.PolicyType.NEVER;
+
         legend_container = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
         legend_container.set_halign (Gtk.Align.CENTER);
+        legend_container.margin_bottom = 9;
+        legend.add (legend_container);
 
         foreach (PartitionBar p in partitions) {
             add_legend (p.path, p.get_size() * 512, Distinst.strfilesys (p.filesystem), p.menu);
@@ -94,7 +99,6 @@ public class Installer.DiskBar: Gtk.Grid {
         path.use_markup = true;
 
         var legend = new Gtk.Grid ();
-        legend.row_spacing = 3;
         legend.column_spacing = 6;
         legend.attach (set_menu (fill_round, menu), 0, 0, 1, 2);
         legend.attach (set_menu (path, menu), 1, 0);
@@ -103,19 +107,19 @@ public class Installer.DiskBar: Gtk.Grid {
         legend_container.pack_start(legend, false, false, 0);
     }
 
-    private Gtk.EventBox set_menu (Gtk.Widget widget, PartitionMenu? menu) {
-        var event_box = new Gtk.EventBox ();
-        event_box.add (widget);
-
+    private Gtk.Widget set_menu (Gtk.Widget widget, PartitionMenu? menu) {
         if (menu != null) {
+            var event_box = new Gtk.EventBox ();
+            event_box.add (widget);
             event_box.add_events (Gdk.EventMask.BUTTON_PRESS_MASK);
             event_box.button_press_event.connect (() => {
                 menu.popup();
                 return true;
             });
+            return event_box;
         }
 
-        return event_box;
+        return widget;
     }
 
     private void generate_label () {
@@ -131,7 +135,7 @@ public class Installer.DiskBar: Gtk.Grid {
         label = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
         label.pack_start (name_label, false, false, 0);
         label.pack_start (size_label, false, false, 0);
-        label.set_margin_right (12);
+        label.margin_end = 12;
         label.valign = Gtk.Align.CENTER;
     }
 


### PR DESCRIPTION
If there are many partitions on a disk, the list of legends will cause
the window to expand to accompany them. To fix this, the legends are now
placed with a scrolled window that scrolls horizontally if the number of
legends exceeds the width of the window.