### PR TITLE
More intelligent partition width calculations

### DIFF
--- a/src/Widgets/PartitionBar.vala
+++ b/src/Widgets/PartitionBar.vala
@@ -70,10 +70,14 @@ public class Installer.PartitionBar : Gtk.EventBox {
         return (((double) this.get_size () / (double) disk_sectors));
     }
 
-    public void update_length (int alloc_width, uint64 disk_sectors) {
+    public int calculate_length (int alloc_width, uint64 disk_sectors) {
         var request = alloc_width * get_percent (disk_sectors);
         if (request < 20) request = 20;
-        set_size_request ((int) request, -1);
+        return (int) request;
+    }
+
+    public void update_length (int request) {
+        set_size_request (request, -1);
     }
 
     public void show_popover () {


### PR DESCRIPTION
This should fix issues with small partitions causing all disk bars to increase in width, giving the illusion of unused space being greater than it actually is. It also fixes the disk bar to respond to changes in width of the parent when it is resized.

Closes #45 
