### PR TITLE
Add Unused Legend If More Than 1%

### DIFF
--- a/src/Widgets/DiskBar.vala
+++ b/src/Widgets/DiskBar.vala
@@ -78,7 +78,9 @@ public class Installer.DiskBar: Gtk.Grid {
             add_legend (p.path, p.get_size() * 512, Distinst.strfilesys (p.filesystem), p.menu);
         }
 
-        add_legend ("unused", unused, "unused", null);
+        if (size / 100 < unused) {
+            add_legend ("unused", unused, "unused", null);
+        }
     }
 
     private void add_legend (string ppath, uint64 size, string fs, PartitionMenu? menu) {


### PR DESCRIPTION
This will change the legends so that the unused legend is only added when the unused space is more than 1% of the disk size.