### PR TITLE
Install to Pre-existing LUKS-encrypted LVM partitions

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -153,7 +153,10 @@ public class Installer.MainWindow : Gtk.Dialog {
         });
 
         partition_view.next_step.connect (() => {
-            load_progress_view ((owned) partition_view.mounts);
+            unowned Configuration config = Configuration.get_default ();
+            config.luks = (owned) partition_view.luks;
+            config.mounts = (owned) partition_view.mounts;
+            load_progress_view ();
         });
     }
 
@@ -187,15 +190,15 @@ public class Installer.MainWindow : Gtk.Dialog {
             stack.visible_child = try_install_view;
         });
 
-        disk_view.next_step.connect (() => load_progress_view (null));
+        disk_view.next_step.connect (() => load_progress_view ());
     }
 
-    private void load_progress_view (Gee.ArrayList<Installer.Mount>? disk_config) {
+    private void load_progress_view () {
         if (progress_view != null) {
             progress_view.destroy ();
         }
 
-        progress_view = new ProgressView (disk_config);
+        progress_view = new ProgressView ();
         stack.add (progress_view);
         stack.visible_child = progress_view;
 

--- a/src/Objects/Configuration.vala
+++ b/src/Objects/Configuration.vala
@@ -34,4 +34,6 @@ public class Configuration : GLib.Object {
     public string? keyboard_variant { get; set; default = null; }
     public string? encryption_password { get; set; default = null; }
     public string disk { get; set; }
+    public Gee.ArrayList<Installer.Mount>? mounts { get; set; default = null; }
+    public Gee.ArrayList<Installer.LuksCredentials>? luks { get; set; default = null; }
 }

--- a/src/Objects/Mount.vala
+++ b/src/Objects/Mount.vala
@@ -28,6 +28,7 @@ public class Installer.Mount {
 
     public const uint8 FORMAT = 1;
     public const uint8 LVM = 2;
+    public const uint8 LVM_ON_LUKS = 4;
 
     public Mount (string partition, string parent_disk, string mount,
                   uint8 flags, Distinst.FileSystemType fs,
@@ -39,7 +40,6 @@ public class Installer.Mount {
         this.menu = menu;
         this.parent_disk = parent_disk;
     }
-
     public bool is_valid_boot_mount () {
         return filesystem == Distinst.FileSystemType.FAT16
             || filesystem == Distinst.FileSystemType.FAT32;
@@ -57,5 +57,17 @@ public class Installer.Mount {
 
     public bool should_format () {
         return (this.flags & FORMAT) != 0;
+    }
+}
+
+public class Installer.LuksCredentials {
+    public string device;
+    public string pv;
+    public string password;
+
+    public LuksCredentials (string device, string pv, string password) {
+        this.device = device;
+        this.pv = pv;
+        this.password = password;
     }
 }

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -28,6 +28,7 @@ public class Installer.PartitioningView : AbstractInstallerView  {
     private Gtk.SizeGroup label_sizer;
 
     public Gee.ArrayList<Installer.Mount> mounts;
+    public Gee.ArrayList<LuksCredentials> luks;
 
     public static uint64 minimum_disk_size;
 
@@ -38,6 +39,7 @@ public class Installer.PartitioningView : AbstractInstallerView  {
 
     construct {
         this.mounts = new Gee.ArrayList<Installer.Mount> ();
+        this.luks = new Gee.ArrayList<LuksCredentials> ();
         this.margin = 12;
 
         disk_list = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
@@ -130,6 +132,7 @@ public class Installer.PartitioningView : AbstractInstallerView  {
     private void reset_view () {
         disk_list.get_children ().foreach ((child) => child.destroy ());
         mounts.clear ();
+        luks.clear ();
         next_button.sensitive = false;
         load_disks ();
     }
@@ -197,6 +200,7 @@ public class Installer.PartitioningView : AbstractInstallerView  {
                 unowned Distinst.LvmDevice disk = disks.get_logical_device (pv);
                 add_logical_disk (disk);
                 menu.set_decrypted (pv);
+                luks.add (new LuksCredentials (device, pv, password));
                 break;
             case 1:
                 stderr.printf ("decrypt_partition result is 1\n");

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -24,7 +24,8 @@ public class Installer.PartitioningView : AbstractInstallerView  {
     private Gtk.Button next_button;
     private Gtk.Button gparted_button;
     private Distinst.Disks disks;
-    private Gtk.Grid disk_list;
+    private Gtk.Box disk_list;
+    private Gtk.SizeGroup label_sizer;
 
     public Gee.ArrayList<Installer.Mount> mounts;
 
@@ -38,9 +39,9 @@ public class Installer.PartitioningView : AbstractInstallerView  {
     construct {
         this.mounts = new Gee.ArrayList<Installer.Mount> ();
         this.margin = 12;
-        disk_list = new Gtk.Grid ();
+
+        disk_list = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
         disk_list.set_valign (Gtk.Align.START);
-        disk_list.row_spacing = 6;
         disk_list.margin_end = 12;
 
         var disk_scroller = new Gtk.ScrolledWindow (null, null);
@@ -73,7 +74,7 @@ public class Installer.PartitioningView : AbstractInstallerView  {
     private void load_disks () {
         disks = Distinst.Disks.probe ();
         disks.initialize_volume_groups ();
-        var label_sizer = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
+        label_sizer = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
 
         var id = 0;
         foreach (unowned Distinst.Disk disk in disks.list ()) {
@@ -97,36 +98,19 @@ public class Installer.PartitioningView : AbstractInstallerView  {
 
             var partitions = new Gee.ArrayList<PartitionBar> ();
             foreach (unowned Distinst.Partition part in disk.list_partitions ()) {
-                var partition = new PartitionBar (part, path, sector_size, false, this.set_mount, this.unset_mount);
+                var partition = new PartitionBar (part, path, sector_size, false, this.set_mount, this.unset_mount, this.decrypt);
                 partitions.add (partition);
             }
 
             var disk_bar = new DiskBar (model, path, size, (owned) partitions);
             label_sizer.add_widget (disk_bar.label);
-            disk_list.attach(disk_bar, 0, id);
+            disk_list.pack_start (disk_bar);
 
             id += 1;
         }
 
         foreach (unowned Distinst.LvmDevice disk in disks.list_logical ()) {
-            var sector_size = disk.get_sector_size ();
-            var size = disk.get_sectors () * sector_size;
-
-            string path = Utils.string_from_utf8 (disk.get_device_path ());
-
-            string model = disk.get_model ();
-
-            var partitions = new Gee.ArrayList<PartitionBar> ();
-            foreach (unowned Distinst.Partition part in disk.list_partitions ()) {
-                var partition = new PartitionBar (part, path, sector_size, true, this.set_mount, this.unset_mount);
-                partitions.add (partition);
-            }
-
-            var disk_bar = new DiskBar (model, path, size, (owned) partitions);
-            label_sizer.add_widget (disk_bar.label);
-            disk_list.attach(disk_bar, 0, id);
-
-            id += 1;
+            add_logical_disk (disk);
         }
 
         disk_list.show_all ();
@@ -148,6 +132,25 @@ public class Installer.PartitioningView : AbstractInstallerView  {
         mounts.clear ();
         next_button.sensitive = false;
         load_disks ();
+    }
+
+    private void add_logical_disk (Distinst.LvmDevice disk) {
+        var sector_size = disk.get_sector_size ();
+        var size = disk.get_sectors () * sector_size;
+
+        string path = Utils.string_from_utf8 (disk.get_device_path ());
+
+        string model = disk.get_model ();
+
+        var partitions = new Gee.ArrayList<PartitionBar> ();
+        foreach (unowned Distinst.Partition part in disk.list_partitions ()) {
+            var partition = new PartitionBar (part, path, sector_size, true, this.set_mount, this.unset_mount, this.decrypt);
+            partitions.add (partition);
+        }
+
+        var disk_bar = new DiskBar (model, path, size, (owned) partitions);
+        label_sizer.add_widget (disk_bar.label);
+        disk_list.pack_start (disk_bar);
     }
 
     private void validate_status () {
@@ -174,6 +177,43 @@ public class Installer.PartitioningView : AbstractInstallerView  {
         }
 
         next_button.sensitive = false;
+    }
+
+    private void decrypt (string device, string pv, string password, DecryptMenu menu) {
+        int result = disks.decrypt_partition (device, Distinst.LvmEncryption () {
+            physical_volume = pv,
+            password = password,
+            keydata = null
+        });
+
+        switch (result) {
+            case 0:
+                unowned Distinst.LvmDevice disk = disks.get_logical_device (pv);
+                add_logical_disk (disk);
+                menu.set_decrypted (pv);
+                break;
+            case 1:
+                stderr.printf ("decrypt_partition result is 1\n");
+                break;
+            case 2:
+                stderr.printf ("decrypt: input was not valid UTF-8\n");
+                break;
+            case 3:
+                stderr.printf ("decrypt: either a password or keydata string must be supplied\n");
+                break;
+            case 4:
+                stderr.printf ("decrypt: unable to decrypt partition (possibly invalid password)\n");
+                break;
+            case 5:
+                stderr.printf ("decrypt: the decrypted partition does not have a LVM volume on it\n");
+                break;
+            case 6:
+                stderr.printf ("decrypt: unable to locate LUKS partition at %s\n", device);
+                break;
+            default:
+                stderr.printf ("decrypt: unhandled error value: %d\n", result);
+                break;
+        }
     }
 
     private void set_mount (Mount mount) {

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -20,8 +20,6 @@ public class ProgressView : AbstractInstallerView {
     public signal void on_success ();
     public signal void on_error ();
 
-    private Gee.ArrayList<Installer.Mount>? disk_config;
-
     private double prev_upper_adj = 0;
     private Gtk.ScrolledWindow terminal_output;
     public Gtk.TextView terminal_view { get; construct; }
@@ -29,11 +27,11 @@ public class ProgressView : AbstractInstallerView {
     private Gtk.Label progressbar_label;
     private const int NUM_STEP = 5;
 
-    public ProgressView (Gee.ArrayList<Installer.Mount>? mounts) {
-        if (mounts == null) {
+    public ProgressView () {
+        unowned Configuration config = Configuration.get_default ();
+        if (config.mounts == null) {
             stderr.printf ("mounts is null\n");
         }
-        this.disk_config = mounts;
     }
 
     construct {
@@ -126,8 +124,6 @@ public class ProgressView : AbstractInstallerView {
         return terminal_view.buffer.text;
     }
 
-    // TODO: This should receive the disk configuration from the user.
-    // For now, it is hard-coded as an example.
     public void start_installation () {
         var installer = new Distinst.Installer ();
         installer.on_error (installation_error_callback);
@@ -163,7 +159,7 @@ public class ProgressView : AbstractInstallerView {
         // to each disk should be made, and where critical partitions are located.
         var disks = new Distinst.Disks ();
 
-        if (disk_config == null) {
+        if (current_config.mounts == null) {
             default_disk_configuration (disks);
         } else {
             custom_disk_configuration (disks);
@@ -184,9 +180,10 @@ public class ProgressView : AbstractInstallerView {
     }
 
     private void custom_disk_configuration (Distinst.Disks disks) {
+        unowned Configuration config = Configuration.get_default ();
         Installer.Mount[] lvm_devices = {};
 
-        foreach (Installer.Mount m in disk_config) {
+        foreach (Installer.Mount m in config.mounts) {
             if (m.is_lvm ()) {
                 lvm_devices += m;
             } else {
@@ -238,6 +235,15 @@ public class ProgressView : AbstractInstallerView {
         }
 
         disks.initialize_volume_groups ();
+
+        foreach (Installer.LuksCredentials cred in config.luks) {
+            disks.decrypt_partition (cred.device, Distinst.LvmEncryption () {
+                physical_volume = cred.pv,
+                password = cred.password,
+                keydata = null
+            });
+        }
+
         foreach (Installer.Mount m in lvm_devices) {
             var vg = m.parent_disk.offset (12);
             unowned Distinst.LvmDevice disk = disks.get_logical_device (vg);

--- a/src/Widgets/DecryptMenu.vala
+++ b/src/Widgets/DecryptMenu.vala
@@ -1,0 +1,102 @@
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/*-
+ * Copyright (c) 2016-2018 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Michael Aaron Murphy <michael@system76.com>
+ */
+
+ public delegate void DecryptFn (string path, string pv, string pass, Installer.DecryptMenu menu);
+
+public class Installer.DecryptMenu: Gtk.Popover {
+    private Gtk.Stack container;
+
+    private Gtk.Container decrypt_view;
+    private Gtk.Button decrypt_button;
+    private Gtk.Entry pass_entry;
+    private Gtk.Entry pv_entry;
+
+    public DecryptMenu (string device_path, DecryptFn decrypt) {
+        container = new Gtk.Stack ();
+        container.margin = 12;
+        create_decrypt_view (device_path, decrypt);
+        add (container);
+        container.show_all ();
+    }
+
+    private void create_decrypt_view (string device_path, DecryptFn decrypt) {
+        pass_entry = new Gtk.Entry ();
+        pass_entry.placeholder_text = "Password";
+        pass_entry.changed.connect (() => set_sensitivity ());
+        pass_entry.activate.connect (() => {
+            if (entries_set ()) {
+                decrypt (device_path, pv_entry.get_text (), pass_entry.get_text (), this);
+            }
+        });
+
+        pv_entry = new Gtk.Entry ();
+        pv_entry.placeholder_text = "Physical Volume";
+        pv_entry.changed.connect (() => set_sensitivity ());
+        pv_entry.activate.connect (() => {
+            if (entries_set ()) {
+                decrypt (device_path, pv_entry.get_text (), pass_entry.get_text (), this);
+            }
+        });
+
+        decrypt_button = new Gtk.Button.with_label (_("Decrypt"));
+        decrypt_button.clicked.connect (() => {
+            decrypt (device_path, pv_entry.get_text (), pass_entry.get_text (), this);
+        });
+
+
+
+        decrypt_view = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
+        decrypt_view.add(pass_entry);
+        decrypt_view.add(pv_entry);
+        decrypt_view.add(decrypt_button);
+
+        container.add (decrypt_view);
+        container.set_visible_child (decrypt_view);
+    }
+
+    private void create_decrypted_view (string pv) {
+        var label = new Gtk.Label ("<b>%s</b>".printf (pv));
+        label.use_markup = true;
+
+        var info = new Gtk.Label (_("LUKS volume was decrypted"));
+
+        var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
+        box.add (label);
+        box.add (info);
+        box.show_all ();
+
+        container.add (box);
+        container.set_visible_child (box);
+    }
+
+    private bool entries_set () {
+        return pass_entry.get_text ().length != 0
+            && pv_entry.get_text ().length != 0;
+    }
+
+    private void set_sensitivity () {
+        decrypt_button.set_sensitive(entries_set ());
+    }
+
+    public void set_decrypted (string pv) {
+        popdown();
+        create_decrypted_view (pv);
+    }
+}

--- a/src/Widgets/DecryptMenu.vala
+++ b/src/Widgets/DecryptMenu.vala
@@ -38,6 +38,8 @@ public class Installer.DecryptMenu: Gtk.Popover {
 
     private void create_decrypt_view (string device_path, DecryptFn decrypt) {
         pass_entry = new Gtk.Entry ();
+        pass_entry.input_purpose = Gtk.InputPurpose.PASSWORD;
+        pass_entry.set_visibility (false);
         pass_entry.placeholder_text = "Password";
         pass_entry.changed.connect (() => set_sensitivity ());
         pass_entry.activate.connect (() => {
@@ -59,8 +61,6 @@ public class Installer.DecryptMenu: Gtk.Popover {
         decrypt_button.clicked.connect (() => {
             decrypt (device_path, pv_entry.get_text (), pass_entry.get_text (), this);
         });
-
-
 
         decrypt_view = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
         decrypt_view.add(pass_entry);

--- a/src/Widgets/DiskBar.vala
+++ b/src/Widgets/DiskBar.vala
@@ -86,7 +86,7 @@ public class Installer.DiskBar: Gtk.Grid {
         add_legend ("unused", unused, "unused", null);
     }
 
-    private void add_legend (string ppath, uint64 size, string fs, PartitionMenu? menu) {
+    private void add_legend (string ppath, uint64 size, string fs, Gtk.Popover? menu) {
         var fill_round = new FillRound ();
         fill_round.set_valign(Gtk.Align.CENTER);
 
@@ -107,7 +107,7 @@ public class Installer.DiskBar: Gtk.Grid {
         legend_container.pack_start(legend, false, false, 0);
     }
 
-    private Gtk.Widget set_menu (Gtk.Widget widget, PartitionMenu? menu) {
+    private Gtk.Widget set_menu (Gtk.Widget widget, Gtk.Popover? menu) {
         if (menu != null) {
             var event_box = new Gtk.EventBox ();
             event_box.add (widget);
@@ -148,7 +148,6 @@ public class Installer.DiskBar: Gtk.Grid {
         bar.set_size_request (-1, 40);
         bar.get_style_context ().add_class ("trough");
         bar.get_style_context ().add_class ("disk-bar");
-        bar.pack_start (unused_bar, true, true, 0);
         bar.size_allocate.connect ((alloc) => {
             update_sector_lengths(partitions, alloc.width);
         });
@@ -157,6 +156,7 @@ public class Installer.DiskBar: Gtk.Grid {
             bar.pack_start(part, false, false, 0);
         }
 
+        bar.pack_start (unused_bar, true, true, 0);
         update_sector_lengths (partitions, 876);
     }
 

--- a/src/Widgets/PartitionBar.vala
+++ b/src/Widgets/PartitionBar.vala
@@ -28,12 +28,12 @@ public class Installer.PartitionBar : Gtk.EventBox {
 
     public Distinst.Partition* info;
     public Gtk.Label label;
-    public PartitionMenu menu;
+    public Gtk.Popover menu;
     public Distinst.FileSystemType filesystem;
 
     public PartitionBar(Distinst.Partition* part, string parent_path,
                         uint64 sector_size, bool lvm, SetMount set_mount,
-                        UnsetMount unset_mount) {
+                        UnsetMount unset_mount, DecryptFn decrypt) {
         start = part->get_start_sector ();
         end = part->get_end_sector ();
 
@@ -51,7 +51,12 @@ public class Installer.PartitionBar : Gtk.EventBox {
         container = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         container.get_style_context ().add_class (Distinst.strfilesys (filesystem));
 
-        menu = new PartitionMenu (path, parent_path, filesystem, lvm, set_mount, unset_mount);
+        if (filesystem == Distinst.FileSystemType.LUKS) {
+            menu = new DecryptMenu (path, decrypt);
+        } else {
+            menu = new PartitionMenu (path, parent_path, filesystem, lvm, set_mount, unset_mount);
+        }
+
         menu.relative_to = container;
 
         add(container);

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -23,7 +23,6 @@ public delegate void SetMount (Installer.Mount mount);
 public delegate void UnsetMount (string partition);
 
 public class Installer.PartitionMenu : Gtk.Popover {
-    private Gtk.Grid grid;
     public bool disable_signals;
     public bool is_lvm;
     public Gtk.ComboBoxText type;
@@ -44,7 +43,8 @@ public class Installer.PartitionMenu : Gtk.Popover {
         is_lvm = lvm;
         partition_path = path;
         parent_disk = parent;
-        grid = new Gtk.Grid ();
+
+        var grid = new Gtk.Grid ();
         grid.column_spacing = 12;
         grid.row_spacing = 6;
         grid.margin = 12;

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,6 +22,7 @@ vala_files = [
     'Views/ProgressView.vala',
     'Views/TryInstallView.vala',
     'Views/SuccessView.vala',
+    'Widgets/DecryptMenu.vala',
     'Widgets/DiskBar.vala',
     'Widgets/DiskGrid.vala',
     'Widgets/LayoutWidget.vala',


### PR DESCRIPTION
- LUKS partitions now display a unique decryption popover
- After decryption, the new LVM device is added to the list
- The LUKS partition will then have its menu altered to reflect the change

### What Remains:

- [x] Distinst should close the LUKS device when decrypting, if it is open
- [x] Ability to install with selected encrypted partitions
- [x] Fix an issue in distinst with blockdev and the opened LUKS device
