### PR TITLE
Guess the desired partition use by the pre-existing file system

### DIFF
--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -189,7 +189,11 @@ public class Installer.PartitionMenu : Gtk.Popover {
                 disable_signals = true;
                 set_format_sensitivity ();
                 disable_signals = false;
-                update_values (set_mount);
+                use_as.set_active (
+                    (fs == Distinst.FileSystemType.FAT16 || fs == Distinst.FileSystemType.FAT32)
+                        ? 2
+                        : fs == Distinst.FileSystemType.SWAP ? 3 : 0
+                );
             } else {
                 unset_mount (partition_path);
             }


### PR DESCRIPTION
When toggling a partition to be used, this will change the behavior so that:

- If the partition is FAT{16,32}, it will be assumed by default that the partition will be used as the boot partition
- If the partition is Swap, it will be assumed that it is going to be used as swap
- If the partition is neither, it will assume root

This should reduce the number of clicks required to set custom mount points.