### PR TITLE
Generate Unique /dev/mapper IDs Via Distinst

### DIFF
--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -272,11 +272,19 @@ public class ProgressView : AbstractInstallerView {
     private void default_disk_configuration (Distinst.Disks disks) {
         unowned Configuration current_config = Configuration.get_default ();
 
+        var encrypted_vg = Distinst.generate_unique_id ("cryptdata");
+        var root_vg = Distinst.generate_unique_id ("data");
+        if (encrypted_vg == null || root_vg == null) {
+            warning ("unable to generate unique volume group ID\n");
+            on_error ();
+            return;
+        }
+
         Distinst.LvmEncryption? encryption;
         if (current_config.encryption_password != null) {
             debug ("encrypting");
             encryption = Distinst.LvmEncryption () {
-                physical_volume = "cryptdata",
+                physical_volume = encrypted_vg,
                 password = current_config.encryption_password,
                 keydata = null
             };
@@ -392,7 +400,7 @@ public class ProgressView : AbstractInstallerView {
         result = disk.add_partition (
             new Distinst.PartitionBuilder (start, end, Distinst.FileSystemType.LVM)
                 .partition_type (Distinst.PartitionType.PRIMARY)
-                .logical_volume ("data", encryption)
+                .logical_volume (root_vg, encryption)
         );
 
         if (result != 0) {
@@ -411,7 +419,7 @@ public class ProgressView : AbstractInstallerView {
             return;
         }
 
-        unowned Distinst.LvmDevice lvm_device = disks.find_logical_volume ("data");
+        unowned Distinst.LvmDevice lvm_device = disks.find_logical_volume (root_vg);
 
         if (lvm_device == null) {
             warning ("unable to find 'data' volume group on %s\n", current_config.disk);


### PR DESCRIPTION
Haven't tested it yet, but this should generate unique IDs when doing a default automated install.