### PR TITLE
Update partition buttons

### DIFF
--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -99,7 +99,7 @@ public class Installer.DiskView : AbstractInstallerView {
         content_area.attach (title_grid, 0, 0, 1, 1);
         content_area.attach (load_stack, 1, 0, 1, 1);
 
-        var custom_button = new Gtk.Button.with_label (_("Custom Partitioning"));
+        var custom_button = new Gtk.Button.with_label (_("Customize Partitions…"));
         custom_button.clicked.connect (() => custom_step ());
         action_area.add (custom_button);
         action_area.set_child_secondary (custom_button, true);

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -60,15 +60,16 @@ public class Installer.PartitioningView : AbstractInstallerView  {
 
         load_disks ();
 
-        gparted_button = new Gtk.Button.with_label (_("Modify Partitions"));
+        gparted_button = new Gtk.Button.with_label (_("Modify Partitions…"));
         gparted_button.clicked.connect (() => open_gparted ());
+        action_area.add (gparted_button);
+        action_area.set_child_secondary (gparted_button, true);
+        action_area.set_child_non_homogeneous (gparted_button, true);
 
         next_button = new Gtk.Button.with_label (_("Erase and Install"));
         next_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
         next_button.sensitive = false;
         next_button.clicked.connect (() => next_step ());
-
-        action_area.add (gparted_button);
         action_area.add (next_button);
 
         show_all ();


### PR DESCRIPTION
This matches the design we discussed in the elementary Slack. My only concern with this now is that "Customize Partitions" might be confusingly similar to "Modify Partitions," so we might want to come up with better copy for that.

In a previous design, we were just planning on using "Custom…" since the question is: "Choose a drive" and you're actively not choosing one of the defaults. But I don't know if that's clear or not.

---

Cassidy James Blaede [11:25 AM]
>@danrabbit on the disk selection screen, should a "Customize Partitions" button be in the alternate position, or the "incidental" position?
>And should it have an ellipsis since it takes you to a different screen without performing an action?

Daniel Foré [11:25 AM]
>I would think incidental

Cassidy James Blaede [11:25 AM]
>My instinct was incidental, with ellipsis

Daniel Foré [11:25 AM]
>and yeah ellipsis because it's a new window (edited)
>:+1:

Cassidy James Blaede [11:25 AM]
>Well it's not technically a new window here, it's a new view in the same window

Daniel Foré [11:26 AM]
>Oh hm

Cassidy James Blaede [11:26 AM]
>But it's kind of like the "Keyboard Settings…" in the Bluetooth plug in that case
>It takes you elsewhere without performing an action on the current view I guess

Daniel Foré [11:26 AM]
>Well, still ellipsis because it's not just an action, it's something you do in a new place

Cassidy James Blaede [11:26 AM]
>:+1:

Daniel Foré [11:26 AM]
>right
