### PR TITLE
Partition Menu UI Tweaks

### DIFF
--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -51,56 +51,39 @@ public class Installer.PartitionMenu : Gtk.Popover {
         partition_path = path;
         parent_disk = parent;
 
-        var grid = new Gtk.Grid ();
-        grid.column_spacing = 12;
-        grid.row_spacing = 6;
-        grid.margin = 6;
+        string boot_partition = (Distinst.bootloader_detect () == Distinst.PartitionTable.GPT)
+            ? "/boot/efi"
+            : "/boot";
 
         var label_size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
 
         var use_partition_label = new Gtk.Label ("Use partition:");
         use_partition_label.halign = Gtk.Align.END;
+        use_partition_label.hexpand = true;
         use_partition_label.xalign = 1;
-
-        var sep = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
-
-        format_label = new Gtk.Label ("Format:");
-        format_label.halign = Gtk.Align.END;
-        format_label.xalign = 1;
         label_size_group.add_widget (format_label);
-
-        var use_as_label = new Gtk.Label ("Use as:");
-        use_as_label.set_halign (Gtk.Align.END);
-        use_as_label.xalign = 1;
-        label_size_group.add_widget (use_as_label);
-
-        custom_label = new Gtk.Label ("Custom:");
-        custom_label.halign = Gtk.Align.END;
-        custom_label.xalign = 1;
-        label_size_group.add_widget (custom_label);
-
-        type_label = new Gtk.Label ("Type:");
-        type_label.halign = Gtk.Align.END;
-        type_label.xalign = 1;
-        label_size_group.add_widget (type_label);
-
-        grid.attach (sep,          0, 0, 2, 1);
-        grid.attach (format_label, 0, 1, 1, 1);
-        grid.attach (use_as_label, 0, 2, 1, 1);
-        grid.attach (custom_label, 0, 3, 1, 1);
-        grid.attach (type_label,   0, 4, 1, 1);
 
         use_partition = new Gtk.Switch ();
         use_partition.halign = Gtk.Align.START;
         use_partition.hexpand = false;
 
+        var separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
+
+        format_label = new Gtk.Label ("Format:");
+        format_label.halign = Gtk.Align.END;
+        format_label.hexpand = true;
+        format_label.xalign = 1;
+        label_size_group.add_widget (format_label);
+
         format_partition = new Gtk.Switch ();
         format_partition.halign = Gtk.Align.START;
         format_partition.hexpand = false;
 
-        string boot_partition = (Distinst.bootloader_detect () == Distinst.PartitionTable.GPT)
-            ? "/boot/efi"
-            : "/boot";
+        var use_as_label = new Gtk.Label ("Use as:");
+        use_as_label.halign = Gtk.Align.END;
+        use_as_label.hexpand = true;
+        use_as_label.xalign = 1;
+        label_size_group.add_widget (use_as_label);
 
         use_as = new Gtk.ComboBoxText ();
         use_as.append_text (_("Root (/)"));
@@ -110,7 +93,19 @@ public class Installer.PartitionMenu : Gtk.Popover {
         use_as.append_text (_("Custom"));
         use_as.set_active (0);
 
+        custom_label = new Gtk.Label ("Custom:");
+        custom_label.halign = Gtk.Align.END;
+        custom_label.hexpand = true;
+        custom_label.xalign = 1;
+        label_size_group.add_widget (custom_label);
+
         custom = new Gtk.Entry ();
+
+        type_label = new Gtk.Label ("Type:");
+        type_label.halign = Gtk.Align.END;
+        type_label.hexpand = true;
+        type_label.xalign = 1;
+        label_size_group.add_widget (type_label);
 
         type = new Gtk.ComboBoxText ();
         type.append_text (_("Default (ext4)"));
@@ -120,26 +115,42 @@ public class Installer.PartitionMenu : Gtk.Popover {
         type.append_text ("xfs");
         type.append_text ("ntfs");
         type.set_active (0);
+        
+        var top_controls = new Gtk.Grid ();
+        top_controls.column_spacing = 12;
+        top_controls.row_spacing = 6;
+        top_controls.margin = 6;
 
-        grid.attach (format_partition, 1, 1, 1, 1);
-        grid.attach (use_as,           1, 2, 1, 1);
-        grid.attach (custom,           1, 3, 1, 1);
-        grid.attach (type,             1, 4, 1, 1);
+        top_controls.attach (use_partition_label, 0, 0, 1, 1);
+        top_controls.attach (use_partition,       1, 0, 1, 1);
 
-        var outer = new Gtk.Grid ();
-        // outer.row_spacing = 6;
-        outer.column_spacing = 12;
-        outer.margin = 12;
+        var bottom_controls = new Gtk.Grid ();
+        bottom_controls.column_spacing = 12;
+        bottom_controls.row_spacing = 6;
+        bottom_controls.margin = 6;
 
-        var outer_revealer = new Gtk.Revealer ();
-        outer_revealer.add (grid);
+        bottom_controls.attach (format_label, 0, 1);
+        bottom_controls.attach (use_as_label, 0, 2);
+        bottom_controls.attach (custom_label, 0, 3);
+        bottom_controls.attach (type_label,   0, 4);
 
-        outer.attach (use_partition_label, 0, 0);
-        outer.attach (use_partition, 1, 0);
-        outer.attach (outer_revealer, 0, 1, 2, 1);
+        bottom_controls.attach (format_partition, 1, 1);
+        bottom_controls.attach (use_as,           1, 2);
+        bottom_controls.attach (custom,           1, 3);
+        bottom_controls.attach (type,             1, 4);
 
-        this.add (outer);
-        outer.show_all ();
+        var grid = new Gtk.Grid ();
+        grid.column_spacing = 12;
+
+        var revealer = new Gtk.Revealer ();
+        // revealer.add (separator);
+        revealer.add (bottom_controls);
+
+        grid.attach (top_controls, 0, 0, 1, 1);
+        grid.attach (revealer,     0, 1, 1, 1);
+
+        this.add (grid);
+        grid.show_all ();
 
         custom.set_visible (false);
         custom_label.set_visible (false);
@@ -152,7 +163,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
             }
         });
 
-        use_as.changed.connect(() => {
+        use_as.changed.connect (() => {
             if (disable_signals) {
                 return;
             }
@@ -193,14 +204,14 @@ public class Installer.PartitionMenu : Gtk.Popover {
             check_values (set_mount);
         });
 
-        type.changed.connect(() => {
+        type.changed.connect (() => {
             if (!disable_signals) {
                 check_values (set_mount);
                 set_format_sensitivity ();
             }
         });
 
-        custom.changed.connect(() => {
+        custom.changed.connect (() => {
             if (!disable_signals) {
                 check_values (set_mount);
             }
@@ -230,7 +241,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
                 partition_bar.container.get_children ().foreach ((c) => c.destroy ());
             }
 
-            outer_revealer.set_reveal_child (use_partition.active);
+            revealer.set_reveal_child (use_partition.active);
             format_partition.set_visible (use_partition.active);
             format_label.set_visible (use_partition.active);
         });

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -54,31 +54,49 @@ public class Installer.PartitionMenu : Gtk.Popover {
         var grid = new Gtk.Grid ();
         grid.column_spacing = 12;
         grid.row_spacing = 6;
-        grid.margin = 12;
+        grid.margin = 6;
+
+        var label_size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
 
         var use_partition_label = new Gtk.Label ("Use partition:");
+        use_partition_label.halign = Gtk.Align.END;
+        use_partition_label.xalign = 1;
+
+        var sep = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
+
         format_label = new Gtk.Label ("Format:");
+        format_label.halign = Gtk.Align.END;
+        format_label.xalign = 1;
+        label_size_group.add_widget (format_label);
+
         var use_as_label = new Gtk.Label ("Use as:");
-        custom_label = new Gtk.Label ("Custom:");
-        type_label = new Gtk.Label ("Type:");
-
-        custom_label.set_halign (Gtk.Align.END);
-        format_label.set_halign (Gtk.Align.END);
-        type_label.set_halign (Gtk.Align.END);
         use_as_label.set_halign (Gtk.Align.END);
-        use_partition_label.set_halign (Gtk.Align.END);
+        use_as_label.xalign = 1;
+        label_size_group.add_widget (use_as_label);
 
-        grid.attach (format_label, 0, 0);
-        grid.attach (use_as_label, 0, 1);
-        grid.attach (custom_label, 0, 2);
-        grid.attach (type_label, 0, 3);
+        custom_label = new Gtk.Label ("Custom:");
+        custom_label.halign = Gtk.Align.END;
+        custom_label.xalign = 1;
+        label_size_group.add_widget (custom_label);
+
+        type_label = new Gtk.Label ("Type:");
+        type_label.halign = Gtk.Align.END;
+        type_label.xalign = 1;
+        label_size_group.add_widget (type_label);
+
+        grid.attach (sep,          0, 0, 2, 1);
+        grid.attach (format_label, 0, 1, 1, 1);
+        grid.attach (use_as_label, 0, 2, 1, 1);
+        grid.attach (custom_label, 0, 3, 1, 1);
+        grid.attach (type_label,   0, 4, 1, 1);
 
         use_partition = new Gtk.Switch ();
-        use_partition.set_halign (Gtk.Align.START);
-        use_partition.set_hexpand (true);
+        use_partition.halign = Gtk.Align.START;
+        use_partition.hexpand = false;
 
         format_partition = new Gtk.Switch ();
-        format_partition.set_halign (Gtk.Align.START);
+        format_partition.halign = Gtk.Align.START;
+        format_partition.hexpand = false;
 
         string boot_partition = (Distinst.bootloader_detect () == Distinst.PartitionTable.GPT)
             ? "/boot/efi"
@@ -103,15 +121,15 @@ public class Installer.PartitionMenu : Gtk.Popover {
         type.append_text ("ntfs");
         type.set_active (0);
 
-        grid.attach (format_partition, 1, 0);
-        grid.attach (use_as, 1, 1);
-        grid.attach (custom, 1, 2);
-        grid.attach (type, 1, 3);
+        grid.attach (format_partition, 1, 1, 1, 1);
+        grid.attach (use_as,           1, 2, 1, 1);
+        grid.attach (custom,           1, 3, 1, 1);
+        grid.attach (type,             1, 4, 1, 1);
 
         var outer = new Gtk.Grid ();
-        outer.row_spacing = 6;
-        outer.column_spacing = 12;;
-        outer.margin = 6;
+        // outer.row_spacing = 6;
+        outer.column_spacing = 12;
+        outer.margin = 12;
 
         var outer_revealer = new Gtk.Revealer ();
         outer_revealer.add (grid);

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -19,7 +19,7 @@
  */
 
 public delegate void SetMount (Installer.Mount mount);
- 
+
 public delegate void UnsetMount (string partition);
 
 public delegate bool MountSetFn (string mount_point);

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -116,7 +116,6 @@ public class Installer.PartitionMenu : Gtk.Popover {
         top_controls.column_spacing = 12;
         top_controls.row_spacing = 6;
         top_controls.margin = 12;
-        top_controls.margin_bottom = 6;
 
         top_controls.attach (use_partition_label, 0, 0, 1, 1);
         top_controls.attach (use_partition,       1, 0, 1, 1);

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -117,8 +117,8 @@ public class Installer.PartitionMenu : Gtk.Popover {
         top_controls.row_spacing = 6;
         top_controls.margin = 12;
 
-        top_controls.attach (use_partition_label, 0, 0, 1, 1);
-        top_controls.attach (use_partition,       1, 0, 1, 1);
+        top_controls.attach (use_partition_label, 0, 0);
+        top_controls.attach (use_partition,       1, 0);
 
         var bottom_controls = new Gtk.Grid ();
         bottom_controls.column_spacing = 12;
@@ -140,8 +140,8 @@ public class Installer.PartitionMenu : Gtk.Popover {
         bottom_grid.column_spacing = 12;
         bottom_grid.row_spacing = 6;
 
-        bottom_grid.attach (separator,       0, 0, 1, 1);
-        bottom_grid.attach (bottom_controls, 0, 1, 1, 1);
+        bottom_grid.attach (separator,       0, 0);
+        bottom_grid.attach (bottom_controls, 0, 1);
 
         var grid = new Gtk.Grid ();
         grid.column_spacing = 12;
@@ -149,8 +149,8 @@ public class Installer.PartitionMenu : Gtk.Popover {
         var bottom_revealer = new Gtk.Revealer ();
         bottom_revealer.add (bottom_grid);
 
-        grid.attach (top_controls,    0, 0, 1, 1);
-        grid.attach (bottom_revealer, 0, 1, 1, 1);
+        grid.attach (top_controls,    0, 0);
+        grid.attach (bottom_revealer, 0, 1);
 
         this.add (grid);
         grid.show_all ();
@@ -295,7 +295,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
         mount_icon.halign = Gtk.Align.END;
         mount_icon.valign = Gtk.Align.END;
         mount_icon.margin = 2;
-        partition_bar.container.get_children ().foreach((c) => c.destroy ());
+        partition_bar.container.get_children ().foreach ((c) => c.destroy ());
         partition_bar.container.pack_start(mount_icon, true, true, 0);
         partition_bar.container.show_all ();
     }

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -105,13 +105,13 @@ public class Installer.PartitionMenu : Gtk.Popover {
 
         type = new Gtk.ComboBoxText ();
         type.append_text (_("Default (ext4)"));
-        type.append_text ("fat16"); 
+        type.append_text ("fat16");
         type.append_text ("fat32");
         type.append_text ("btrfs");
         type.append_text ("xfs");
         type.append_text ("ntfs");
         type.active = 0;
-        
+
         var top_controls = new Gtk.Grid ();
         top_controls.column_spacing = 12;
         top_controls.row_spacing = 6;
@@ -156,7 +156,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
         this.add (grid);
         grid.show_all ();
 
-        // FIXME: Probably should stick these in a revealer, too 
+        // FIXME: Probably should stick these in a revealer, too
         custom.visible = false;
         custom_label.visible = false;
 


### PR DESCRIPTION
This looks like a much bigger change than it is… but I reworked the PartitionMenu a bit. The main difference is the alignment and margins, plus a new separator (which we should style in the Pop! GTK theme). While I was here, I updated it to be more elementary code-style.