### PR TITLE
Fix recovery disk selection

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -81,7 +81,8 @@ public class Installer.MainWindow : Gtk.Dialog {
         stack.visible_child = keyboard_layout_view;
 
         keyboard_layout_view.next_step.connect (() => {
-            if (Recovery.disk () == null || !Recovery.get_default().oem_mode) {
+            var recovery = Recovery.get_default ();
+            if (recovery == null || !recovery.oem_mode) {
                 load_try_install_view ();
             } else {
                 load_encrypt_view ();

--- a/src/Objects/Configuration.vala
+++ b/src/Objects/Configuration.vala
@@ -34,6 +34,7 @@ public class Configuration : GLib.Object {
     public string? keyboard_variant { get; set; default = null; }
     public string? encryption_password { get; set; default = null; }
     public string disk { get; set; }
+    public bool recovery { get; set; default = false; }
     public Gee.ArrayList<Installer.Mount>? mounts { get; set; default = null; }
     public Gee.ArrayList<Installer.LuksCredentials>? luks { get; set; default = null; }
 }

--- a/src/Objects/Recovery.vala
+++ b/src/Objects/Recovery.vala
@@ -34,7 +34,10 @@ public class Recovery : GLib.Object {
     }
 
     public static string? efi_partition () {
-        unowned Recovery recovery = Recovery.get_default ();
+        unowned Recovery? recovery = Recovery.get_default ();
+        if (recovery == null) {
+            return null;
+        }
 
         if (recovery.efi_uuid != null) {
             return Posix.realpath ("/dev/disk/by-uuid/" + recovery.efi_uuid);
@@ -44,7 +47,10 @@ public class Recovery : GLib.Object {
     }
 
     public static string? recovery_partition () {
-        unowned Recovery recovery = Recovery.get_default ();
+        unowned Recovery? recovery = Recovery.get_default ();
+        if (recovery == null) {
+            return null;
+        }
 
         if (recovery.recovery_uuid != null) {
             return Posix.realpath ("/dev/disk/by-uuid/" + recovery.recovery_uuid);
@@ -54,7 +60,10 @@ public class Recovery : GLib.Object {
     }
 
     public static string? root_partition () {
-        unowned Recovery recovery = Recovery.get_default ();
+        unowned Recovery? recovery = Recovery.get_default ();
+        if (recovery == null) {
+            return null;
+        }
 
         if (recovery.root_uuid != null) {
             return Posix.realpath ("/dev/disk/by-uuid/" + recovery.root_uuid);
@@ -130,6 +139,10 @@ public class Recovery : GLib.Object {
     }
 
     private static Recovery? load (string path) throws GLib.Error {
+        if (!GLib.File.new_for_path (path).query_exists ()) {
+            return null;
+        }
+
         var recovery = new Recovery();
 
         var data_stream = new DataInputStream (File.new_for_path (path).read ());

--- a/src/Objects/Recovery.vala
+++ b/src/Objects/Recovery.vala
@@ -183,6 +183,7 @@ public class Recovery : GLib.Object {
                 recovery.root_uuid = val;
             } else if (name == "OEM_MODE" && val == "1") {
                 recovery.oem_mode = true;
+                Configuration.get_default ().recovery = true;
             }
         }
 

--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -114,7 +114,7 @@ public class Installer.DiskView : AbstractInstallerView {
         Distinst.Disks disks = Distinst.Disks.probe ();
         foreach (unowned Distinst.Disk disk in disks.list ()) {
             // Skip root disk or live disk
-            if (!Recovery.get_default().oem_mode && (disk.contains_mount ("/") || disk.contains_mount ("/cdrom"))) {
+            if (Recovery.get_default () == null && (disk.contains_mount ("/") || disk.contains_mount ("/cdrom"))) {
                 continue;
             }
 

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -129,7 +129,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
 
         foreach (unowned Distinst.Disk disk in disks.list ()) {
             // Skip root disk or live disk
-            if (!Recovery.get_default().oem_mode && (disk.contains_mount ("/") || disk.contains_mount ("/cdrom"))) {
+            if (Recovery.get_default() == null && (disk.contains_mount ("/") || disk.contains_mount ("/cdrom"))) {
                 continue;
             }
 

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -185,6 +185,7 @@ public class ProgressView : AbstractInstallerView {
             var recovery = Recovery.disk ();
             if (recovery == null) {
                 on_error ();
+                return;
             }
 
             if (!recovery_disk_configuration (disks, recovery)) {

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -43,8 +43,7 @@ public class ProgressView : AbstractInstallerView {
         terminal_view.get_style_context ().add_class ("terminal");
 
         terminal_output = new Gtk.ScrolledWindow (null, null);
-        terminal_output.hscrollbar_policy = Gtk.PolicyType.AUTOMATIC;
-        terminal_output.propagate_natural_width = true;
+        terminal_output.hscrollbar_policy = Gtk.PolicyType.NEVER;
         terminal_output.expand = true;
         terminal_output.add (terminal_view);
 
@@ -168,8 +167,6 @@ public class ProgressView : AbstractInstallerView {
 
         unowned Configuration current_config = Configuration.get_default ();
 
-        var recovery = Recovery.disk ();
-
         debug ("language: %s\n", current_config.lang);
         if (current_config.country != null) {
             debug ("country: %s\n", current_config.country);
@@ -184,7 +181,12 @@ public class ProgressView : AbstractInstallerView {
         config.keyboard_variant = current_config.keyboard_variant;
 
         var disks = new Distinst.Disks ();
-        if (recovery != null && Recovery.get_default().oem_mode) {
+        if (current_config.recovery) {
+            var recovery = Recovery.disk ();
+            if (recovery == null) {
+                on_error ();
+            }
+
             if (!recovery_disk_configuration (disks, recovery)) {
                 on_error ();
                 return;

--- a/src/Widgets/DiskGrid.vala
+++ b/src/Widgets/DiskGrid.vala
@@ -62,7 +62,12 @@ public class Installer.DiskButton : Gtk.ToggleButton {
         notify["active"].connect (() => {
             if (active) {
                 unowned Configuration config = Configuration.get_default ();
-                config.disk = disk_path;
+                var recovery = Recovery.disk ();
+                if (recovery != null && recovery == disk_path) {
+                    config.recovery = true;
+                } else {
+                    config.disk = disk_path;
+                }
             }
         });
     }


### PR DESCRIPTION
If the recovery file exists and OEM_MODE is set to 0, this
will enable the drive where the recovery partition exists
to be selected for install

@brs17 This should fix the disk-hiding issue that hides the disk where the recovery partition exists.