### PR TITLE
Use distinst for default locale requests w/ missing country field

### DIFF
--- a/src/Objects/Configuration.vala
+++ b/src/Objects/Configuration.vala
@@ -38,15 +38,20 @@ public class Configuration : GLib.Object {
     public Gee.ArrayList<Installer.Mount>? mounts { get; set; default = null; }
     public Gee.ArrayList<Installer.LuksCredentials>? luks { get; set; default = null; }
 
+    /**
+     * Uses distinst to attempt to get a default locale if no country is available.
+     *
+     * - If a country is provided, a locale will be generated without distinst's help.
+     * - If distinst returns a null value, we will default to `en_US.UTF-8`.
+     **/
     public string get_locale() {
         if (country == null) {
-            switch (lang) {
-                case "da":
-                    country = "DK";
-                    break;
-                default:
-                    country = lang.ascii_up ();
-                    break;
+            string? default = Distinst.locale_get_default (lang);
+            if (default == null) {
+                warning ("distinst could not generate a default locale for %s\n", lang);
+                return "en_US.UTF-8";
+            } else {
+                return default;
             }
         }
 

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -140,6 +140,9 @@ public class ProgressView : AbstractInstallerView {
 
     public void start_installation () {
         if (Installer.App.test_mode) {
+            unowned Configuration current_config = Configuration.get_default ();
+
+            stderr.printf ("locale: %s\n", current_config.get_locale ());
             new Thread<void*> (null, () => {
                 fake_status (Distinst.Step.PARTITION);
                 fake_status (Distinst.Step.EXTRACT);
@@ -167,7 +170,7 @@ public class ProgressView : AbstractInstallerView {
 
         unowned Configuration current_config = Configuration.get_default ();
 
-        debug ("locale: %s\n", current_config.get_locale ());
+        stderr.printf ("locale: %s\n", current_config.get_locale ());
         config.lang = current_config.get_locale ();
         config.keyboard_layout = current_config.keyboard_layout;
         config.keyboard_model = null;


### PR DESCRIPTION
Rather than hardcoding values within the installer, distinst will be used to request for a locale based on available locales in `/usr/share/i18n/SUPPORTED`. When given a lang like `es`, it will return `es_ES.UTF-8`, and when given a lang like `da`, it will return `da_DK.UTF-8`. If a locale cannot be found for a language, this will default to `en_US.UTF-8`, and print a warning.

Countries may also be requested, for providing better country detection that what currently exists, but that's for another PR.

(requires a very recent version of distinst)