### PR TITLE
[WIP] LocaleHelper Rust Rewrite

### DIFF
--- a/src/Helpers/LocaleHelper.vala
+++ b/src/Helpers/LocaleHelper.vala
@@ -18,17 +18,12 @@
 
 namespace LocaleHelper {
     public class LangEntry {
-        public string alpha_3;
-        public string? alpha_2;
-        public string name;
+        public string code;
+        public string? name;
         public CountryEntry[] countries;
 
         public LangEntry () {
             countries = {};
-        }
-
-        public string get_code () {
-            return alpha_2 ?? alpha_3;
         }
 
         public void add_country (CountryEntry country_entry) {
@@ -36,151 +31,47 @@ namespace LocaleHelper {
             _countries += country_entry;
             countries = _countries;
         }
+
+        public unowned string get_code() {
+            return code;
+        }
     }
 
     public struct CountryEntry {
-        public string alpha_2;
-        public string alpha_3;
-        public string name;
+        public string code;
+        public string? name;
     }
 
-    private static Gee.HashMap<string, LangEntry?> lang_entries;
-    public static Gee.HashMap<string, LangEntry?> get_lang_entries () {
+    private static Gee.HashMap<string, LangEntry> lang_entries;
+
+    public static Gee.HashMap<string, LangEntry> get_lang_entries () {
         if (lang_entries == null) {
-            lang_entries = new Gee.HashMap<string, LangEntry?> ();
-            var langs = Build.LANG_LIST.split (";");
+            lang_entries = new Gee.HashMap<string, LangEntry> ();
 
-            var parser = new Json.Parser ();
-            try {
-                parser.load_from_file ("/usr/share/iso-codes/json/iso_639-3.json");
-                weak Json.Object root_object = parser.get_root ().get_object ();
-                weak Json.Array 639_3_array = root_object.get_array_member ("639-3");
-                foreach (unowned Json.Node element in 639_3_array.get_elements ()) {
-                    weak Json.Object object = element.get_object ();
-                    var entry = new LangEntry ();
-                    entry.alpha_3 = object.get_string_member ("alpha_3");
-                    if (object.has_member ("alpha_2")) {
-                        entry.alpha_2 = object.get_string_member ("alpha_2");
-                    }
+            foreach (var language in Distinst.locale_get_language_codes ()) {
+                var lang_entry = new LangEntry () {
+                    code = language,
+                    name = Distinst.locale_get_language_name_translated (language)
+                };
 
-                    var key_string = entry.get_code ();
-                    entry.name = object.get_string_member ("name");
-                    if (key_string in langs) {
-                        lang_entries[key_string] = entry;
-                    }
-                }
-            } catch (Error e) {
-                critical (e.message);
-            }
-
-            var countries = new Gee.HashMap<string, CountryEntry?> ();
-            parser = new Json.Parser ();
-            try {
-                parser.load_from_file ("/usr/share/iso-codes/json/iso_3166-1.json");
-                weak Json.Object root_object = parser.get_root ().get_object ();
-                weak Json.Array 639_3_array = root_object.get_array_member ("3166-1");
-                foreach (unowned Json.Node element in 639_3_array.get_elements ()) {
-                    weak Json.Object object = element.get_object ();
-                    var entry = CountryEntry ();
-                    entry.alpha_3 = object.get_string_member ("alpha_3");
-                    entry.alpha_2 = object.get_string_member ("alpha_2");
-                    entry.name = object.get_string_member ("name");
-                    countries[entry.alpha_2] = entry;
-                }
-            } catch (Error e) {
-                critical (e.message);
-            }
-
-            foreach (var lang in langs) {
-                if (!("_" in lang)) {
-                    continue;
+                foreach (var country in Distinst.locale_get_country_codes (language)) {
+                    lang_entry.add_country(CountryEntry () {
+                        code = country,
+                        name = Distinst.locale_get_country_name_translated (country, language)
+                    });
                 }
 
-                var parts = lang.split ("_", 2);
-                var lang_entry = lang_entries[parts[0]];
-                var country = countries[parts[1]];
-                if (country != null && lang_entry != null) {
-                    lang_entry.add_country (country);
-                }
-            }
-
-            // Now translate the labels in their original language.
-            var current_lang = Environment.get_variable ("LANGUAGE");
-            foreach (var lang_entry in lang_entries.values) {
-                var lang_code = lang_entry.get_code ();
-                Environment.set_variable ("LANGUAGE", lang_code, true);
-                lang_entry.name = dgettext ("iso_639_3", lang_entry.name);
-                if (lang_entry.countries.length > 0) {
-                    lang_entry.name = _("%s…").printf (lang_entry.name);
-                }
-
-                foreach (var country in lang_entry.countries) {
-                    Environment.set_variable ("LANGUAGE", lang_code + "_" + country.alpha_2, true);
-                    country.name = dgettext ("iso_3166", country.name);
-                }
-            }
-
-            if (current_lang != null) {
-                Environment.set_variable ("LANGUAGE", current_lang, true);
-            } else {
-                Environment.unset_variable ("LANGUAGE");
+                lang_entries[language] = lang_entry;
             }
         }
 
         return lang_entries;
     }
 
-    // Taken from the /usr/share/language-tools/main-countries script.
     public static string? get_main_country (string lang_prefix) {
-        switch (lang_prefix) {
-            case "aa":
-                return "ET";
-            case "ar":
-                return "EG";
-            case "bn":
-                return "BD";
-            case "ca":
-                return "ES";
-            case "da":
-                return "DK";
-            case "de":
-                return "DE";
-            case "el":
-                return "GR";
-            case "en":
-                return "US";
-            case "es":
-                return "ES";
-            case "eu":
-                return "ES";
-            case "fr":
-                return "FR";
-            case "fy":
-                return "NL";
-            case "it":
-                return "IT";
-            case "li":
-                return "NL";
-            case "nl":
-                return "NL";
-            case "om":
-                return "ET";
-            case "pa":
-                return "PK";
-            case "pt":
-                return "PT";
-            case "ru":
-                return "RU";
-            case "so":
-                return "SO";
-            case "sr":
-                return "RS";
-            case "sv":
-                return "SE";
-            case "ti":
-                return "ER";
-            case "tr":
-                return "TR";
+        string? main = Distinst.locale_get_main_country (lang_prefix);
+        if (main != null) {
+            return main;
         }
 
         // We fallback to whatever is available in the lang list.

--- a/src/Views/LanguageView.vala
+++ b/src/Views/LanguageView.vala
@@ -127,7 +127,7 @@ public class Installer.LanguageView : AbstractInstallerView {
 
                 unowned Gtk.ListBoxRow crow = lang_variant_widget.variant_listbox.get_selected_row ();
                 if (crow != null) {
-                    string country = ((CountryRow) crow).country_entry.alpha_2;
+                    string country = ((CountryRow) crow).country_entry.code;
                     configuration.country = country;
                 } else if (lang_entry.countries.length == 0) {
                     configuration.country = null;
@@ -193,7 +193,7 @@ public class Installer.LanguageView : AbstractInstallerView {
         foreach (Gtk.Widget child in lang_variant_widget.variant_listbox.get_children ()) {
             if (child is CountryRow) {
                 var country_row = (CountryRow) child;
-                if (country_row.country_entry.alpha_2 == country_entry.alpha_2) {
+                if (country_row.country_entry.code == country_entry.code) {
                     country_row.selected = true;
                 } else {
                     country_row.selected = false;


### PR DESCRIPTION
**This isn't ready to merge just yet, but it will be ready soon.**

- Less Vala (installer), More Rust (distinst)
- Language codes, their country codes, and their codesets are parsed from `/usr/share/i18n/SUPPORTED`
- The [isolang](https://crates.io/crates/isolang) crate is used to convert language codes to their names
- The [iso3166-1](https://crates.io/crates/iso3166-1) crate is used to convert country codes to their names
- The [gettext-rs](https://crates.io/crates/gettext-rs) crate will translate them accordingly.