### PR TITLE
Fix for logical devices with dashes in names

### DIFF
--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -649,7 +649,7 @@ public class ProgressView : AbstractInstallerView {
         }
 
         foreach (Installer.Mount m in lvm_devices) {
-            var vg = m.parent_disk.offset (12);
+            var vg = m.parent_disk.offset (12).replace("--", "-");
             unowned Distinst.LvmDevice disk = disks.get_logical_device (vg);
             if (disk == null) {
                 critical ("could not find %s\n", vg);


### PR DESCRIPTION
Requires https://github.com/pop-os/distinst/pull/97

The installer gets the volume group name in the custom partitioning view from the volume group's device path (ie: `/dev/mapper/pop_os--vg`). Because device paths will have dashes doubled, this will get the correct volume name from the path (`pop_os-vg`).