### PR TITLE
Support FS on LUKS

### DIFF
--- a/src/Objects/InstallOptions.vala
+++ b/src/Objects/InstallOptions.vala
@@ -47,6 +47,10 @@ public class InstallOptions : GLib.Object {
         return null != recovery && recovery.get_oem_mode ();
     }
 
+    public bool contains_luks () {
+        return disks.contains_luks ();
+    }
+
     public unowned Distinst.InstallOptions get_options () {
         if (null == _options) {
             disks = Distinst.Disks.probe ();
@@ -73,6 +77,10 @@ public class InstallOptions : GLib.Object {
 
     public Distinst.Disks get_disks () {
         return (owned) disks;
+    }
+
+    public unowned Distinst.Disks borrow_disks () {
+        return disks;
     }
 
     public unowned Distinst.InstallOption? get_selected_option () {

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -190,9 +190,15 @@ public class Installer.PartitioningView : AbstractInstallerView {
         string model = Utils.string_from_utf8 (disk.get_model ());
 
         var partitions = new Gee.ArrayList<PartitionBar> ();
-        foreach (unowned Distinst.Partition part in disk.list_partitions ()) {
-            var partition = new PartitionBar (part, path, sector_size, true, this.set_mount, this.unset_mount, this.mount_is_set, this.decrypt);
-            partitions.add (partition);
+
+        Distinst.Partition? poss_part = disk.get_encrypted_file_system ();
+        if (poss_part != null) {
+            partitions.add (new PartitionBar (poss_part, path, sector_size, true, this.set_mount, this.unset_mount, this.mount_is_set, this.decrypt));
+        } else {
+            foreach (unowned Distinst.Partition part in disk.list_partitions ()) {
+                var partition = new PartitionBar (part, path, sector_size, true, this.set_mount, this.unset_mount, this.mount_is_set, this.decrypt);
+                partitions.add (partition);
+            }
         }
 
         var disk_bar = new DiskBar (model, path, size, (owned) partitions);

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -191,7 +191,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
 
         var partitions = new Gee.ArrayList<PartitionBar> ();
 
-        Distinst.Partition? poss_part = disk.get_encrypted_file_system ();
+        unowned Distinst.Partition? poss_part = disk.get_encrypted_file_system ();
         if (poss_part != null) {
             partitions.add (new PartitionBar (poss_part, path, sector_size, true, this.set_mount, this.unset_mount, this.mount_is_set, this.decrypt));
         } else {
@@ -225,7 +225,8 @@ public class Installer.PartitioningView : AbstractInstallerView {
         stderr.printf ("DEBUG: Current Layout:\n");
         foreach (Mount m in mounts) {
             stderr.printf (
-                "  %s : %s : %s: format? %s\n",
+                "  %s : %s : %s : %s: format? %s\n",
+                m.parent_disk,
                 m.partition_path,
                 m.mount_point,
                 Distinst.strfilesys (m.filesystem),

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -211,7 +211,7 @@ public class ProgressView : AbstractInstallerView {
                 return;
             }
         } else {
-            disks = new Distinst.Disks ();
+            disks = Distinst.Disks.probe ();
             if (!custom_disk_configuration (disks)) {
                 on_error ();
                 return;
@@ -297,11 +297,13 @@ public class ProgressView : AbstractInstallerView {
                 return false;
             }
 
-            unowned Distinst.Partition partition = disk.get_partition_by_path (m.partition_path);
-
+            unowned Distinst.Partition partition = disk.get_encrypted_file_system ();
             if (partition == null) {
-                critical ("could not find %s\n", m.partition_path);
-                return false;
+                partition = disk.get_partition_by_path (m.partition_path);
+                if (partition == null) {
+                    critical ("could not find by path %s\n", m.partition_path);
+                    return false;
+                }
             }
 
             if (m.filesystem != Distinst.FileSystemType.SWAP) {


### PR DESCRIPTION
- Requires, and is required by https://github.com/pop-os/distinst/pull/107
- Enables ability to decrypt and install to LUKS devices that don't use LVM
  - IE: Ext4 on LUKS, versus LVM on LUKS
- Adds `contains_luks ()` and `borrow_disks ()` methods to `InstallOptions`