### PR TITLE
Don't probe disks on a custom install

### DIFF
--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -167,7 +167,7 @@ public class ProgressView : AbstractInstallerView {
                 return;
             }
         } else {
-            disks = Distinst.Disks.probe ();
+            disks = new Distinst.Disks ();
             if (!custom_disk_configuration (disks)) {
                 on_error ();
                 return;


### PR DESCRIPTION
A full on probe can be a very time-consuming operation. It's not necessary for a custom install, where mounts have already been defined previously.