### PR TITLE
Deactivate PVs & VGs on launch & backing from custom partitioning

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -60,6 +60,7 @@ public class Installer.App : Gtk.Application {
 }
 
 public static int main (string[] args) {
+    Distinst.deactivate_logical_devices ();
     var application = new Installer.App ();
     return application.run (args);
 }

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -124,7 +124,10 @@ public class Installer.PartitioningView : AbstractInstallerView {
             help_dialog.transient_for = (Gtk.Window) get_toplevel ();
         });
         modify_partitions_button.clicked.connect (() => open_partition_editor ());
-        back_button.clicked.connect (() => ((Gtk.Stack) get_parent ()).visible_child = previous_view);
+        back_button.clicked.connect (() => {
+            Distinst.deactivate_logical_devices ();
+            ((Gtk.Stack) get_parent ()).visible_child = previous_view;
+        });
         next_button.clicked.connect (() => next_step ());
 
         show_all ();

--- a/src/Widgets/DecryptMenu.vala
+++ b/src/Widgets/DecryptMenu.vala
@@ -89,8 +89,9 @@ public class Installer.DecryptMenu: Gtk.Popover {
         pv_label.halign = Gtk.Align.END;
 
         pv_entry = new Gtk.Entry ();
-        // Set a sane default
-        pv_entry.text = "data";
+        string? pv_uid = Distinst.generate_unique_id("cryptdata");
+        pv_entry.text = pv_uid != null ? pv_uid : "";
+
         pv_entry.changed.connect (set_sensitivity);
         pv_entry.activate.connect (attempt_decrypt);
 
@@ -130,7 +131,7 @@ public class Installer.DecryptMenu: Gtk.Popover {
                 mount_icon.halign = Gtk.Align.END;
                 mount_icon.valign = Gtk.Align.END;
                 mount_icon.margin = 6;
-    
+
                 partition_bar.container.pack_start (mount_icon, true, true, 0);
                 partition_bar.container.show_all ();
                 this.destroy ();
@@ -187,4 +188,3 @@ public class Installer.DecryptMenu: Gtk.Popover {
         });
     }
 }
-

--- a/src/Widgets/DecryptMenu.vala
+++ b/src/Widgets/DecryptMenu.vala
@@ -89,8 +89,7 @@ public class Installer.DecryptMenu: Gtk.Popover {
         pv_label.halign = Gtk.Align.END;
 
         pv_entry = new Gtk.Entry ();
-        string? pv_uid = Distinst.generate_unique_id("cryptdata");
-        pv_entry.text = pv_uid != null ? pv_uid : "";
+        pv_entry.text = "cryptdata";
 
         pv_entry.changed.connect (set_sensitivity);
         pv_entry.activate.connect (attempt_decrypt);
@@ -115,6 +114,12 @@ public class Installer.DecryptMenu: Gtk.Popover {
         stack.add (decrypt_view);
         stack.visible_child = decrypt_view;
         pass_entry.grab_focus_without_selecting ();
+
+        // Update the default LUKS PV name, to prevent namespace conflicts.
+        this.notify["active"].connect (() => {
+            string? pv_uid = Distinst.generate_unique_id("cryptdata");
+            pv_entry.text = pv_uid != null ? pv_uid : "";
+        });
 
         this.closed.connect (() => {
             stack.visible_child = decrypt_view;


### PR DESCRIPTION
- Deactivates all active PVs and VGs when the installer starts (verified with `dmsetup ls`)
- Deactivates again when selecting the back button in the custom partitioning view
- As an added bonus, the default PV for the decryption popovers is now automatically generated

Closes #148 
Closes #145 

@brs17 