### PR TITLE
Fix segfault

### DIFF
--- a/src/Views/KeyboardLayoutView.vala
+++ b/src/Views/KeyboardLayoutView.vala
@@ -134,7 +134,8 @@ public class KeyboardLayoutView : AbstractInstallerView {
         });
 
         input_variant_widget.variant_listbox.row_selected.connect ((vrow) => {
-            unowned Gtk.ListBoxRow lrow = input_variant_widget.main_listbox.get_selected_row ();
+            if (vrow == null) { return; }
+            unowned Gtk.ListBoxRow? lrow = input_variant_widget.main_listbox.get_selected_row ();
             if (lrow == null) {
                 return;
             } else {

--- a/src/Widgets/VariantWidget.vala
+++ b/src/Widgets/VariantWidget.vala
@@ -68,9 +68,9 @@ public class VariantWidget : Gtk.Frame {
         add (stack);
 
         back_button.clicked.connect (() => {
+            unset_variant ();
             going_to_main ();
             stack.visible_child_name = "main";
-            unset_variant ();
         });
     }
 
@@ -87,8 +87,7 @@ public class VariantWidget : Gtk.Frame {
     }
 
     private void unset_variant () {
-        weak Gtk.ListBoxRow row = variant_listbox.get_selected_row ();
-        if (row != null) variant_listbox.unselect_row (row);
+        variant_listbox.unselect_all ();
     }
 }
 


### PR DESCRIPTION
Fixes #139 

The fix in this PR is just the `if (vrow == null) { return; }` line. I'm not sure why `variant_listbox.row_selected` is triggered when unselecting rows, which then attempts to process a row which does not exist.