### PR TITLE
Logging Fix

### DIFF
--- a/src/Helpers/LogHelper.vala
+++ b/src/Helpers/LogHelper.vala
@@ -56,7 +56,6 @@ public class LogHelper : GLib.Object {
     }
 
     private void log_func (Distinst.LogLevel level, string message) {
-        stdout.printf ("log: %s: %s\n", level_name (level), message);
         Idle.add (() => {
             Gtk.TextIter end_iter;
             buffer.get_end_iter (out end_iter);


### PR DESCRIPTION
With https://github.com/pop-os/distinst/pull/118, distinst is switching to using the [fern](https://docs.rs/fern) crate for its advanced logging configuration capabilities. Thus, distinst now performs multi-directional logging, and stdout is one of those that are supported.