### PR TITLE
Detect if BIOS disk install is too small for MSDOS partition table

### DIFF
--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -162,11 +162,6 @@ public class Installer.DiskView : AbstractInstallerView {
                         next_button.sensitive = true;
                     } else {
                         next_button.sensitive = false;
-                        if (msdos_too_large) {
-                            disk_button.set_tooltip_text (_("Maximum size of MSDOS partition table is 2TiB. Switch to EFI for GPT table support."));
-                        } else {
-                            disk_button.set_tooltip_text (_("Disk does not meet the minimum requirement"));
-                        }
                     }
                 });
 
@@ -186,6 +181,11 @@ public class Installer.DiskView : AbstractInstallerView {
                 enabled_buttons += disk_button;
             } else {
                 disk_button.set_sensitive (false);
+                if (msdos_too_large) {
+                    disk_button.set_tooltip_text (_("Maximum size of MSDOS partition table is 2TiB. Switch to EFI for GPT table support."));
+                } else {
+                    disk_button.set_tooltip_text (_("Disk does not meet the minimum requirement"));
+                }
 
                 disabled_buttons += disk_button;
             }


### PR DESCRIPTION
The max size of a MSDOS partition table is 2TiB.  This will add a check to the "Clean Install" view to disallow selecting disks that exceed this limit when performing a BIOS install. A tooltip will also now display when hovering a mouse over a disk that cannot be selected, to explain why it cannot be installed to.

@brs17 This should make it obvious what's wrong in advance.