### PR TITLE
Increase required EFI size to 500 MiB

### DIFF
--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -45,7 +45,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
         EFI
     }
 
-    const uint64 REQUIRED_EFI_SECTORS = 524288;
+    const uint64 REQUIRED_EFI_SECTORS = 1024000;
 
     construct {
         mounts = new Gee.ArrayList<Installer.Mount> ();
@@ -62,7 +62,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
                 break;
             case Distinst.PartitionTable.GPT:
                 // Device is in EFI mode, so we also require a boot partition
-                required_description = _("You must at least select a <b>Root (/)</b> partition, plus a <b>Boot (/boot/efi)</b> partition that is at least 256 MiB and on a GPT disk.");
+                required_description = _("You must at least select a <b>Root (/)</b> partition, plus a <b>Boot (/boot/efi)</b> partition that is at least 500 MiB and on a GPT disk.");
                 break;
         }
 


### PR DESCRIPTION
Default installs have been set to 500 MiB for quite some time, since 256 MiB is only able to store up to two kernels (+1 recovery kernel) at a time in the EFI partition, and likely won't be enough for two in the near future. 500 MiB gives enough room for ~4 kernels (+1 recovery kernel) + potentially a Windows bootloader.

Closes #175 