### PR TITLE
Use system-os-installer for Clean install icon

### DIFF
--- a/src/Views/TryInstallView.vala
+++ b/src/Views/TryInstallView.vala
@@ -117,7 +117,7 @@ public class Installer.TryInstallView : AbstractInstallerView {
 
         var clean_install_button = button_creator.new_button (
             _("Clean Install"),
-            "gcleaner",
+            "system-os-installer",
             _("Erase everything and install a fresh copy of %s.").printf (pretty_name),
             () => next_step ()
         );


### PR DESCRIPTION
This prevents icon breakage with 19.04, and is a better icon for
that purpose than "gcleaner" anyway. Also, it should be fully
backwards-compatible with older version and the old icon theme.