### PR TITLE
Support sector sizes that are not 512 bytes

### DIFF
--- a/src/Objects/Mount.vala
+++ b/src/Objects/Mount.vala
@@ -23,6 +23,7 @@ public class Installer.Mount {
     public string parent_disk;
     public string mount_point;
     public uint64 sectors;
+    public uint64 sector_size;
     public Distinst.FileSystem filesystem;
     public Flags flags;
     public PartitionMenu menu;
@@ -35,8 +36,8 @@ public class Installer.Mount {
     }
 
     public Mount (string partition, string parent_disk, string mount,
-                  uint64 sectors, Flags flags, Distinst.FileSystem fs,
-                  PartitionMenu menu) {
+                  uint64 sectors, uint64 sector_size, Flags flags,
+                  Distinst.FileSystem fs, PartitionMenu menu) {
         filesystem = fs;
         mount_point = mount;
         partition_path = partition;
@@ -44,6 +45,7 @@ public class Installer.Mount {
         this.menu = menu;
         this.parent_disk = parent_disk;
         this.sectors = sectors;
+        this.sector_size = sector_size;
     }
 
     public bool is_valid_boot_mount () {

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -18,9 +18,13 @@
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
 
-const double SECTORS_AS_GIB = 2 * 1024 * 1024;
+const uint64 SECTORS_AS_GIB = 2 * 1024 * 1024;
 
 namespace Utils {
+    public uint64 normalize_sectors (uint64 base_count, uint64 sector_size) {
+        return base_count / (sector_size / 512);
+    }
+
     public string string_from_utf8 (uint8[] input) {
         var builder = new GLib.StringBuilder.sized (input.length);
         builder.append_len ((string) input, input.length);

--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -46,11 +46,12 @@ public class Installer.DiskView : OptionsView {
         unowned Distinst.InstallOptions options = install_options.get_updated_options ();
 
         foreach (unowned Distinst.EraseOption disk in options.get_erase_options ()) {
+            uint64 sector_size = disk.get_sector_size ();
             string logo = Utils.string_from_utf8 (disk.get_linux_icon ());
             string label = Utils.string_from_utf8 (disk.get_model ());
             string details = "%s %.1f GiB".printf (
                 Utils.string_from_utf8 (disk.get_device_path ()),
-                (double) disk.get_sectors () / SECTORS_AS_GIB
+                (double) disk.get_sectors () / (double) Utils.normalize_sectors(SECTORS_AS_GIB, sector_size)
             );
 
             // Ensure that the user cannot select a disk that is too large for BIOS installs.

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -315,7 +315,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
                 throw new GLib.IOError.FAILED (_("EFI partition is not on a GPT disk"));
             } else if (!mount.is_valid_boot_mount ()) {
                 throw new GLib.IOError.FAILED (_("EFI partition has the wrong file system"));
-            } else if (mount.sectors < REQUIRED_EFI_SECTORS) {
+            } else if (mount.sectors < Utils.normalize_sectors(REQUIRED_EFI_SECTORS, mount.sector_size)) {
                 error = _("EFI partition is too small");
             }
         } else if (mount.mount_point == "/" && !mount.is_valid_root_mount ()) {

--- a/src/Widgets/PartitionBar.vala
+++ b/src/Widgets/PartitionBar.vala
@@ -23,6 +23,7 @@ public class Installer.PartitionBar : Gtk.EventBox {
 
     public uint64 start;
     public uint64 end;
+    public uint64 sector_size;
     public uint64 used;
     public new string path;
     public string? vg;
@@ -38,6 +39,7 @@ public class Installer.PartitionBar : Gtk.EventBox {
                          DecryptFn decrypt) {
         start = part->get_start_sector ();
         end = part->get_end_sector ();
+        this.sector_size = sector_size;
 
         var usage = part->sectors_used (sector_size);
         if (usage.tag == 1) {

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -280,6 +280,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
                 parent_disk,
                 mount,
                 partition_bar.end - partition_bar.start,
+                partition_bar.sector_size,
                 (format_partition.active ? Mount.Flags.FORMAT : 0)
                     + (is_lvm ? Mount.Flags.LVM : 0),
                 filesystem,


### PR DESCRIPTION
Requires https://github.com/pop-os/distinst/pull/181

Needs to be tested with a disk that has 512-byte sector sizes, to ensure that the behavior hasn't changed, and with a disk with a non-512-byte sector size (if we have one).