### PR TITLE
500MiB EFI -> 500MB Requirement

### DIFF
--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -45,7 +45,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
         EFI
     }
 
-    const uint64 REQUIRED_EFI_SECTORS = 1024000;
+    const uint64 REQUIRED_EFI_SECTORS = 500 * 1000 * 1000 / 512;
 
     construct {
         mounts = new Gee.ArrayList<Installer.Mount> ();


### PR DESCRIPTION
This will allow a reinstall from a clean install which is 498 MiB,
and will prevent further issue reports about 500 MiB EFI partitions
that aren't quite 500 MiB.

Closes #187 