### PR TITLE
Remove note that installer is not being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 [![Translation status](https://l10n.elementary.io/widgets/installer/-/svg-badge.svg)](https://l10n.elementary.io/projects/installer/?utm_source=widget)
 [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=46189108)](https://www.bountysource.com/trackers/46189108-elementary-pantheon-installer)
 
-> Note: this is the work-in-progress installer and has not been released yet. For the current installer, see [Ubiquity](https://wiki.ubuntu.com/Ubiquity).
-
 An installer for open-source operating systems. See the [wiki](https://github.com/elementary/installer/wiki) for goals, design spec, user flow, and details about each step.
 
 ## Building, Testing, and Installation


### PR DESCRIPTION
Remove statement that this installer is not being used in production yet (because it has been for a year now).