### PR TITLE
fix: Hide restart button on darp6 and galp4 on 18.04

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -71,10 +71,12 @@ namespace Utils {
 
     private struct OsRelease {
         public string pretty_name;
+        public string version_id;
 
         public static OsRelease new () {
             return OsRelease () {
-                pretty_name = string_from_utf8 (Distinst.get_os_pretty_name ())
+                pretty_name = string_from_utf8 (Distinst.get_os_pretty_name ()),
+                version_id = string_from_utf8 (Distinst.get_os_version_id ())
             };
         }
     }
@@ -87,6 +89,14 @@ namespace Utils {
         }
 
         return os_release.pretty_name;
+    }
+
+    private static string get_version_id () {
+        if (os_release == null) {
+            os_release = OsRelease.new ();
+        }
+
+        return os_release.version_id;
     }
 
     public static void shutdown () {


### PR DESCRIPTION
- Expose the OS version ID in the Utils namespace
- Hide the restart button on 18.04 for the darp6 and falp4