### PR TITLE
Explicitly select disk

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -652,6 +652,7 @@ public class Installer.MainWindow : Gtk.Dialog {
 
         disk_view.previous_view = try_install_view;
         stack.visible_child = disk_view;
+        this.disk_view.reset();
         disk_view.load.begin (minimum_disk_size);
 
         load_check_view ();

--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -63,6 +63,8 @@ public class Installer.DiskView : OptionsView {
             base.add_option(logo, label, details, (button) => {
                 if (disk.meets_requirements () && !msdos_too_large) {
                     button.key_press_event.connect ((event) => handle_key_press (button, event));
+                    button.focus_out_event.connect((event) => handle_focus_out (button));
+                    button.focus_in_event.connect((event) => handle_focus_in (button));
                     button.notify["active"].connect (() => {
                         if (button.active) {
                             base.options.get_children ().foreach ((child) => {
@@ -113,6 +115,16 @@ public class Installer.DiskView : OptionsView {
             return true;
         }
 
+        return false;
+    }
+
+    private bool handle_focus_in (Gtk.Button button) {
+        next_button.sensitive = true;
+        return false;
+    }
+
+    private bool handle_focus_out (Gtk.Button button) {
+        next_button.sensitive = false;
         return false;
     }
 }

--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -62,9 +62,6 @@ public class Installer.DiskView : OptionsView {
 
             base.add_option(logo, label, details, (button) => {
                 if (disk.meets_requirements () && !msdos_too_large) {
-                    button.key_press_event.connect ((event) => handle_key_press (button, event));
-                    button.focus_out_event.connect((event) => handle_focus_out (button));
-                    button.focus_in_event.connect((event) => handle_focus_in (button));
                     button.notify["active"].connect (() => {
                         if (button.active) {
                             base.options.get_children ().foreach ((child) => {
@@ -94,6 +91,7 @@ public class Installer.DiskView : OptionsView {
                             next_button.sensitive = false;
                         }
                     });
+                    button.key_press_event.connect ((event) => handle_key_press (button, event));
                 } else {
                     button.sensitive = false;
                     if (msdos_too_large) {
@@ -109,22 +107,18 @@ public class Installer.DiskView : OptionsView {
     }
 
     private bool handle_key_press (Gtk.Button button, Gdk.EventKey event) {
-        if (event.keyval == Gdk.Key.Return) {
+        if (event.keyval == Gdk.Key.Return && next_button.sensitive) {
             button.clicked ();
             next_button.clicked ();
+            return true;
+        } else if (event.keyval == Gdk.Key.Return && !next_button.sensitive) {
             return true;
         }
 
         return false;
     }
 
-    private bool handle_focus_in (Gtk.Button button) {
-        next_button.sensitive = true;
-        return false;
-    }
-
-    private bool handle_focus_out (Gtk.Button button) {
+    public void reset() {
         next_button.sensitive = false;
-        return false;
     }
 }


### PR DESCRIPTION
## Before
The user can select a drive without the `Erase and Install` being sensitive. It is not clear enough.

https://user-images.githubusercontent.com/58987761/146617494-12a694ce-b976-4b54-b5ad-0a635b10af79.mp4

## After
User is required to select the drive. Either with the mouse or `Space`

https://user-images.githubusercontent.com/58987761/146617506-69d2eedd-1fb4-4345-b426-74f7394dd6db.mp4

This also fixes #250
