### PR TITLE
fix: listen to return key press from beginning

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -186,6 +186,7 @@ public class Installer.MainWindow : Gtk.Dialog {
                 language_view.next_step.connect (() => load_keyboard_view ());
                 stack.add (language_view);
                 stack.visible_child = language_view;
+                language_view.reset();
                 stack.show_all();
             }
 

--- a/src/Views/LanguageView.vala
+++ b/src/Views/LanguageView.vala
@@ -238,7 +238,7 @@ public class Installer.LanguageView : AbstractInstallerView {
             Environment.set_variable ("LANGUAGE", lang_entry.get_code (), true);
             Intl.textdomain (Build.GETTEXT_PACKAGE);
             lang_variant_widget.show_variants (_("Languages"), "<b>%s</b>".printf (lang_entry.name));
-    }
+    } 
 
     private bool timeout () {
         var row = lang_variant_widget.main_listbox.get_row_at_index (select_number);
@@ -350,5 +350,9 @@ public class Installer.LanguageView : AbstractInstallerView {
 
             add (grid);
         }
+    }
+
+    public void reset() {
+        lang_variant_widget.main_listbox.get_selected_row ().grab_focus ();
     }
 }


### PR DESCRIPTION
Currently selecting the default language requires clicking the next button, or change focus with an arrow key/tab then press enter. This sets the focus correctly on the default language, so it can be selected by pressing `enter`

![Screenshot from 2021-12-18 00-25-21](https://user-images.githubusercontent.com/58987761/146622126-dfbef2ee-a220-4340-be6a-3bfeed3afdee.png)

