### PR TITLE
Non-x86 support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Standards-Version: 3.9.6
 Homepage: https://github.com/pop-os/installer
 
 Package: pop-installer
-Architecture: amd64
+Architecture: linux-any
 Priority: extra
 Depends: gparted, distinst-v2, ${misc:Depends}, ${shlibs:Depends}
 Recommends: pop-installer-session
@@ -27,14 +27,14 @@ Description: Distribution installer
  Installs distros with ease, all installs are treated as OEM.
 
 Package: pop-installer-session
-Architecture: amd64
+Architecture: linux-any
 Priority: extra
 Depends: pop-installer
 Description: Dedicated installer session
  Launches pop-installer in a dedicated session.
 
 Package: pop-installer-casper
-Architecture: amd64
+Architecture: linux-any
 Priority: extra
 Depends: casper
 Description: Autostart pop-installer in casper


### PR DESCRIPTION
Now that https://github.com/pop-os/distinst/pull/291 is merged, we can also change pop-installer's Arch to `linux-any`.