### PR TITLE
fix: Remove unclear jargon from EncryptView

### DIFF
--- a/src/Views/EncryptView.vala
+++ b/src/Views/EncryptView.vala
@@ -66,7 +66,7 @@ public class EncryptView : AbstractInstallerView {
 
         var performance_image = new Gtk.Image.from_icon_name ("utilities-system-monitor-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
 
-        var performance_label = new Gtk.Label (_("Drive encryption may minimally impact read and write speed when performing intense tasks.")) {
+        var performance_label = new Gtk.Label (_("Drive encryption may slighty affect read and write speed when performing intense tasks.")) {
             max_width_chars = 52,
             wrap = true,
             xalign = 0


### PR DESCRIPTION
This commit removes the jargon word "impact" from the EncryptView.
Encryption is not crashing into read/write speed, and even in the jargon
sense of "strongly/violently/markedly affect", saying "minimally impact"
makes no sense, so this commit rewrites in clearer language.