### PR TITLE
Allow root to use GUI while installer program is running

### DIFF
--- a/data/io.elementary.installer.desktop.in
+++ b/data/io.elementary.installer.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Install Pop!_OS
 Comment=Install the system
-Exec=pkexec io.elementary.installer
+Exec=sh -c "xhost +si:localuser:root; pkexec io.elementary.installer; xhost -si:localuser:root"
 Icon=system-os-installer
 Terminal=false
 Type=Application


### PR DESCRIPTION
This should allow the installer to launch from the desktop entry inside of COSMIC.