### PR TITLE
Wrap label instead of its text

### DIFF
--- a/src/Views/OptionsView.vala
+++ b/src/Views/OptionsView.vala
@@ -85,7 +85,10 @@ public class OptionsView: AbstractInstallerView {
             var desc_label = new Gtk.Label ("<small>%s</small>".printf (desc));
             desc_label.halign = Gtk.Align.START;
             desc_label.use_markup = true;
+            desc_label.max_width_chars = 50;
             desc_label.valign = Gtk.Align.START;
+            desc_label.wrap = true;
+            desc_label.xalign = 0;
             desc_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
             content.attach (desc_label, 1, 1);
         } else {

--- a/src/Views/RefreshView.vala
+++ b/src/Views/RefreshView.vala
@@ -35,8 +35,7 @@ public class RefreshView: OptionsView {
         string refresh_icon = "view-refresh";
         string refresh_title = _("Refresh Install");
         string refresh_description = _(
-"Reinstall %s while keeping user accounts and files.
-Applications will need to be reinstalled manually."
+"Reinstall %s while keeping user accounts and files. Applications will need to be reinstalled manually."
         ).printf(this.os);
 
         string install_icon = "system-os-installer";


### PR DESCRIPTION
This fixes the following warnings when updating the translation template or translation files:

```
[ryo@b760m ~/work/tmp/pop-installer (update-potfiles)]$ ninja -C builddir io.elementary.installer-pot
ninja: Entering directory `builddir'
[0/1] Running external command io.elementary.installer-pot
src/Views/RefreshView.vala:38: warning: unterminated string literal
src/Views/RefreshView.vala:39: warning: unterminated string literal
[ryo@b760m ~/work/tmp/pop-installer (update-potfiles *)]$
```

It looks like this does not happen on Pop!_OS 22.04 LTS, but I guess it would happen on Pop!_OS 24.04 LTS because I'm facing this warning on elementary OS 8 Early Access which built on Ubuntu 24.04 LTS.

Just removing the newline in the string causes the window width bigger (see https://github.com/pop-os/installer/pull/295#pullrequestreview-2270666253), so make sure to wrap the label.

![VirtualBox_Pop!_OS 22](https://github.com/user-attachments/assets/3961e0de-36e3-4006-adab-e25599ef0699)