### PR TITLE
Correct gettext format

### DIFF
--- a/src/Views/CheckView.vala
+++ b/src/Views/CheckView.vala
@@ -203,7 +203,7 @@ public class Installer.CheckView : AbstractInstallerView {
             case State.SPACE:
                 var grid = setup_grid (
                     _("Not Enough Space"),
-                    _("There is not enough room on your device to install %s. We recommend a minimum of %s of storage.".printf (Utils.get_pretty_name (), GLib.format_size (MINIMUM_SPACE))),
+                    _("There is not enough room on your device to install %s. We recommend a minimum of %s of storage.").printf (Utils.get_pretty_name (), GLib.format_size (MINIMUM_SPACE)),
                     "drive-harddisk"
                 );
                 grid.show_all ();

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -88,7 +88,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
         use_as = new Gtk.ComboBoxText ();
         use_as.append_text (_("Root (/)"));
         use_as.append_text (_("Home (/home)"));
-        use_as.append_text (_("Boot (%s)".printf (boot_partition)));
+        use_as.append_text (_("Boot (%s)").printf (boot_partition));
         use_as.append_text (_("Swap"));
         use_as.append_text (_("Custom"));
         use_as.active = 0;


### PR DESCRIPTION
This PR fixes some strings not shown in translated text.

## Before
![Screenshot from 2024-10-03 00-17-18](https://github.com/user-attachments/assets/3ba039a6-05a0-4894-a20b-ae474198a500)

## After
![Screenshot from 2024-10-03 00-16-50](https://github.com/user-attachments/assets/7dc678b3-8603-47c0-b54e-c798344f0b78)
