### PR TITLE
fix(cosmic): set alternate characters key to ralt by default

### DIFF
--- a/src/Views/KeyboardLayoutView.vala
+++ b/src/Views/KeyboardLayoutView.vala
@@ -239,7 +239,7 @@ public class KeyboardLayoutView : AbstractInstallerView {
         }
 
         try {
-            string contents = @"( rules: \"\", model: \"\", layout: \"$layout\", variant: \"$variant\", options: Some(\"compose:ralt\"), repeat_delay: 600, repeat_rate: 25, )\n";
+            string contents = @"( rules: \"\", model: \"\", layout: \"$layout\", variant: \"$variant\", options: Some(\"lv3:ralt_switch,compose:rctrl\"), repeat_delay: 600, repeat_rate: 25, )\n";
             xkb_config.replace_contents (contents.data, null, false, FileCreateFlags.REPLACE_DESTINATION, null);
         } catch (Error e) {
             critical ("could not write cosmic xkb_config: %s", e.message);


### PR DESCRIPTION
Part of https://github.com/pop-os/cosmic-epoch/issues/2242

Need a similar change for distinst